### PR TITLE
Allow FTP clients to specify list options e.g. ls -la

### DIFF
--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -177,7 +177,7 @@ where
                                 }),
                         );
                     }
-                    Some(ExternalCommand(Command::List { path })) => {
+                    Some(ExternalCommand(Command::List { path, .. })) => {
                         let path = match path {
                             Some(path) => cwd.join(path),
                             None => cwd,


### PR DESCRIPTION
As libunftp Command::List only accepts path arguments and no options, this will break the clients for the MVP. When running the LIST command,
We should atleast ignore any list options (-la, -a) instead of interpreting these as path arguments.

In this PR we ignore the options
