### PR TITLE
Implemented the REST command (#39).

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -579,7 +579,7 @@ where
                                 feat_text.push(" PROT");
                             }
                             if storage_features & storage::FEATURE_RESTART > 0 {
-                                feat_text.push("REST STREAM");
+                                feat_text.push(" REST STREAM");
                             }
 
                             // Show them in alphabetical order.
@@ -815,7 +815,7 @@ where
                             let storage = Arc::clone(&session.storage);
 
                             match storage.size(&session.user, &file).wait() {
-                                Ok(size) => Ok(Reply::new(ReplyCode::FileStatus, &*size.to_string())),
+                                Ok(size) => Ok(Reply::new(ReplyCode::FileStatus, &*(size - session.start_pos).to_string())),
                                 Err(_) => Ok(Reply::new(ReplyCode::FileError, "Could not get size.")),
                             }
                         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -834,10 +834,18 @@ where
                 Event::InternalMsg(NotFound) => Ok(Reply::new(ReplyCode::FileError, "File not found")),
                 Event::InternalMsg(PermissionDenied) => Ok(Reply::new(ReplyCode::FileError, "Permision denied")),
                 Event::InternalMsg(SendingData) => Ok(Reply::new(ReplyCode::FileStatusOkay, "Sending Data")),
-                Event::InternalMsg(SendData { .. }) => Ok(Reply::new(ReplyCode::ClosingDataConnection, "Send you something nice")),
+                Event::InternalMsg(SendData { .. }) => {
+                    let mut session = session.lock()?;
+                    session.start_pos = 0;
+                    Ok(Reply::new(ReplyCode::ClosingDataConnection, "Successfully sent"))
+                }
                 Event::InternalMsg(WriteFailed) => Ok(Reply::new(ReplyCode::TransientFileError, "Failed to write file")),
                 Event::InternalMsg(ConnectionReset) => Ok(Reply::new(ReplyCode::ConnectionClosed, "Datachannel unexpectedly closed")),
-                Event::InternalMsg(WrittenData { .. }) => Ok(Reply::new(ReplyCode::ClosingDataConnection, "File successfully written")),
+                Event::InternalMsg(WrittenData { .. }) => {
+                    let mut session = session.lock()?;
+                    session.start_pos = 0;
+                    Ok(Reply::new(ReplyCode::ClosingDataConnection, "File successfully written"))
+                }
                 Event::InternalMsg(DataConnectionClosedAfterStor) => Ok(Reply::new(ReplyCode::FileActionOkay, "unFTP holds your data for you")),
                 Event::InternalMsg(UnknownRetrieveError) => Ok(Reply::new(ReplyCode::TransientFileError, "Unknown Error")),
                 Event::InternalMsg(DirectorySuccessfullyListed) => Ok(Reply::new(ReplyCode::ClosingDataConnection, "Listed the directory")),

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -48,6 +48,9 @@ where
     // True if the data channel is in secure mode.
     pub data_tls: bool,
     pub with_metrics: bool,
+    // The starting byte for a STOR or RETR command. Set by the _Restart of Interrupted Transfer (REST)_
+    // command to support resume functionality.
+    pub start_pos: u64,
 }
 
 impl<S, U: Send + Sync + 'static> Session<S, U>
@@ -74,6 +77,7 @@ where
             cmd_tls: false,
             data_tls: false,
             with_metrics: false,
+            start_pos: 0,
         }
     }
 

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -165,7 +165,7 @@ where
                         let tx_error = tx.clone();
                         tokio::spawn(
                             storage
-                                .put(&user, tcp_tls_stream, path)
+                                .put(&user, tcp_tls_stream, path, start_pos)
                                 .map_err(|e| {
                                     if let Some(kind) = e.io_error_kind() {
                                         std::io::Error::new(kind, "Failed to put file")

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -114,6 +114,7 @@ where
         let abort_rx = self.data_abort_rx.take().unwrap();
         let storage = Arc::clone(&self.storage);
         let cwd = self.cwd.clone();
+        let start_pos = self.start_pos;
         let task = rx
             .take(1)
             .map(DataCommand::ExternalCommand)
@@ -129,7 +130,7 @@ where
                         let tx_error = tx.clone();
                         tokio::spawn(
                             storage
-                                .get(&user, path)
+                                .get(&user, path, start_pos)
                                 .map_err(|_| std::io::Error::new(ErrorKind::Other, "Failed to get file"))
                                 .and_then(|f| {
                                     tx_sending

--- a/src/storage/cloud_storage.rs
+++ b/src/storage/cloud_storage.rs
@@ -297,7 +297,7 @@ impl<U: Send> StorageBackend<U> for CloudStorage {
         Box::new(result)
     }
 
-    fn get<P: AsRef<Path>>(&self, _user: &Option<U>, path: P, start_pos: u64) -> Box<dyn Future<Item = Self::File, Error = Self::Error> + Send> {
+    fn get<P: AsRef<Path>>(&self, _user: &Option<U>, path: P, _start_pos: u64) -> Box<dyn Future<Item = Self::File, Error = Self::Error> + Send> {
         let uri = match path
             .as_ref()
             .to_str()
@@ -336,7 +336,7 @@ impl<U: Send> StorageBackend<U> for CloudStorage {
         _user: &Option<U>,
         bytes: B,
         path: P,
-        start_pos: u64,
+        _start_pos: u64,
     ) -> Box<dyn Future<Item = u64, Error = Self::Error> + Send> {
         let uri = match path
             .as_ref()

--- a/src/storage/cloud_storage.rs
+++ b/src/storage/cloud_storage.rs
@@ -336,6 +336,7 @@ impl<U: Send> StorageBackend<U> for CloudStorage {
         _user: &Option<U>,
         bytes: B,
         path: P,
+        start_pos: u64,
     ) -> Box<dyn Future<Item = u64, Error = Self::Error> + Send> {
         let uri = match path
             .as_ref()

--- a/src/storage/cloud_storage.rs
+++ b/src/storage/cloud_storage.rs
@@ -297,7 +297,7 @@ impl<U: Send> StorageBackend<U> for CloudStorage {
         Box::new(result)
     }
 
-    fn get<P: AsRef<Path>>(&self, _user: &Option<U>, path: P) -> Box<dyn Future<Item = Self::File, Error = Self::Error> + Send> {
+    fn get<P: AsRef<Path>>(&self, _user: &Option<U>, path: P, start_pos: u64) -> Box<dyn Future<Item = Self::File, Error = Self::Error> + Send> {
         let uri = match path
             .as_ref()
             .to_str()

--- a/src/storage/filesystem.rs
+++ b/src/storage/filesystem.rs
@@ -146,7 +146,7 @@ impl<U: Send> StorageBackend<U> for Filesystem {
 
         let fut = file
             .into_future()
-            .map(|f| tokio::fs::file::File::from_std(f))
+            .map(tokio::fs::file::File::from_std)
             .and_then(move |mut file| file.poll_set_len(start_pos).map(|_| file))
             .and_then(move |file| file.seek(std::io::SeekFrom::Start(start_pos)))
             .map(|f| f.0)
@@ -359,7 +359,7 @@ mod tests {
 
         // Since the filesystem backend is based on futures, we need a runtime to run it
         let mut rt = tokio::runtime::Runtime::new().unwrap();
-        let mut my_file = rt.block_on(fs.get(&Some(AnonymousUser {}), filename)).unwrap();
+        let mut my_file = rt.block_on(fs.get(&Some(AnonymousUser {}), filename, 0)).unwrap();
         let mut my_content = Vec::new();
         rt.block_on(future::lazy(move || {
             tokio::prelude::AsyncRead::read_to_end(&mut my_file, &mut my_content).unwrap();
@@ -385,7 +385,7 @@ mod tests {
         // to completion
         let mut rt = tokio::runtime::Runtime::new().unwrap();
 
-        rt.block_on(fs.put(&Some(AnonymousUser {}), orig_content.as_ref(), "greeting.txt"))
+        rt.block_on(fs.put(&Some(AnonymousUser {}), orig_content.as_ref(), "greeting.txt", 0))
             .expect("Failed to `put` file");
 
         let mut written_content = Vec::new();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -220,11 +220,15 @@ pub trait StorageBackend<U: Send> {
         Box::new(fut)
     }
 
-    /// Returns the content of the given file.
+    /// Returns the content of the given file from offset start_pos.
+    /// The starting position can only be greater than zero if the storage back-end implementation
+    /// advertises to support partial reads through the supported_features method i.e. the result
+    /// from supported_features yield 1 if a logical and operation is applied with FEATURE_RESTART.
+    ///
     // TODO: Future versions of Rust will probably allow use to use `impl Future<...>` here. Use it
     // if/when available. By that time, also see if we can replace Self::File with the AsyncRead
     // Trait.
-    fn get<P: AsRef<Path>>(&self, user: &Option<U>, path: P) -> Box<dyn Future<Item = Self::File, Error = Self::Error> + Send>;
+    fn get<P: AsRef<Path>>(&self, user: &Option<U>, path: P, start_pos: u64) -> Box<dyn Future<Item = Self::File, Error = Self::Error> + Send>;
 
     /// Write the given bytes to the given file.
     fn put<P: AsRef<Path>, R: tokio::prelude::AsyncRead + Send + 'static>(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -5,6 +5,10 @@ use std::{fmt, result};
 use chrono::prelude::*;
 use futures::{Future, Stream};
 
+/// Tells if STOR/RETR restarts are supported by the storage back-end
+/// i.e. starting from a different byte offset.
+pub const FEATURE_RESTART: u32 = 0b0000_0001;
+
 /// `Error` variants that can be produced by the [`StorageBackend`] implementations must implement
 /// this ErrorSemantics trait.
 ///
@@ -154,6 +158,12 @@ pub trait StorageBackend<U: Send> {
     type Metadata: Metadata;
     /// The concrete type of the error returned by this StorageBackend.
     type Error: ErrorSemantics;
+
+    /// Tells which optional features are supported by the storage back-end
+    /// Return a value with bits set according to the FEATURE_* constants.
+    fn supported_features(&self) -> u32 {
+        0
+    }
 
     /// Returns the `Metadata` for the given file.
     ///

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -230,12 +230,13 @@ pub trait StorageBackend<U: Send> {
     // Trait.
     fn get<P: AsRef<Path>>(&self, user: &Option<U>, path: P, start_pos: u64) -> Box<dyn Future<Item = Self::File, Error = Self::Error> + Send>;
 
-    /// Write the given bytes to the given file.
+    /// Write the given bytes to the given file starting at offset
     fn put<P: AsRef<Path>, R: tokio::prelude::AsyncRead + Send + 'static>(
         &self,
         user: &Option<U>,
         bytes: R,
         path: P,
+        start_pos: u64,
     ) -> Box<dyn Future<Item = u64, Error = Self::Error> + Send>;
 
     /// Delete the given file.


### PR DESCRIPTION
This implements the **_Restart of Interrupted Transfer (REST)_** command:

- Its parsing
- Basic Unit test
- Allowing Storage back-ends to say if they support this feature
- Advertising REST in the FEAT response if the storage back-end supports is
- Seeking to the REST offset during a RETR command.
- Seeking to the REST offset during a STOR command.

Only the filesystem back-end currently supports this feature