### PR TITLE
Fixes for FEAT and multiline responses.

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -569,15 +569,20 @@ where
                             Ok(Reply::new(ReplyCode::FileStatusOkay, "Sending directory list"))
                         }
                         Command::Feat => {
-                            let mut feat_text = vec!["Extensions supported:"];
+                            let mut feat_text = vec![" SIZE"];
+                            // Add the features. According to the spec each feature line must be
+                            // indented by a space.
                             if tls_configured {
-                                feat_text.push("AUTH (Authentication/Security Mechanism)");
-                                feat_text.push("PBSZ (Protection Buffer Size)");
-                                feat_text.push("PROT (Data Channel Protection Level)");
+                                feat_text.push(" AUTH TLS");
+                                feat_text.push(" PBSZ");
+                                feat_text.push(" PROT");
                             }
-                            feat_text.push("SIZE (File Transfer Size)");
-                            // Now make sure everything is in the right order for printing to the client
-                            feat_text.reverse();
+
+                            // Show them in alphabetical order.
+                            feat_text.sort();
+                            feat_text.insert(0, "Extensions supported:");
+                            feat_text.push("END");
+
                             let reply = Reply::new_multiline(ReplyCode::SystemStatus, feat_text);
                             Ok(reply)
                         }


### PR DESCRIPTION
FEAT wasn't according to spec. Each feature line should start with a space. Also the features in FEAT are now sorted alphabetically.

Furthermore multiline responses in general wasn't completely accoding to spec. When a line in a multi-line response starts with a number it needs to be indented.