### PR TITLE
Obscure password in format directives

### DIFF
--- a/src/server/commands.rs
+++ b/src/server/commands.rs
@@ -1,3 +1,5 @@
+use crate::server::password::Password;
+
 use bytes::Bytes;
 use failure::*;
 use std::{fmt, result, str};
@@ -78,7 +80,7 @@ pub enum Command {
     /// The `PASS` command
     Pass {
         /// The bytes making up the actual password.
-        password: Bytes,
+        password: Password,
     },
     /// The `ACCT` command
     Acct {
@@ -274,7 +276,9 @@ impl Command {
             }
             "PASS" => {
                 let password = parse_to_eol(cmd_params)?;
-                Command::Pass { password }
+                Command::Pass {
+                    password: Password::new(password),
+                }
             }
             "ACCT" => {
                 let account = parse_to_eol(cmd_params)?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,6 +5,8 @@ pub(crate) mod commands;
 
 pub(crate) mod reply;
 
+pub(crate) mod password;
+
 // Contains code pertaining to the FTP *control* channel
 mod controlchan;
 
@@ -365,7 +367,7 @@ where
                             let session = session.lock()?;
                             match session.state {
                                 SessionState::WaitPass => {
-                                    let pass = std::str::from_utf8(&password)?;
+                                    let pass = std::str::from_utf8(&password.as_ref())?;
                                     let user = session.username.clone().unwrap();
                                     let tx = tx.clone();
 

--- a/src/server/password.rs
+++ b/src/server/password.rs
@@ -9,7 +9,7 @@ pub struct Password {
 
 impl Password {
     pub fn new(bytes: Bytes) -> Self {
-        Password { bytes: bytes }
+        Password { bytes }
     }
 }
 

--- a/src/server/password.rs
+++ b/src/server/password.rs
@@ -21,7 +21,7 @@ impl fmt::Display for Password {
 
 impl fmt::Debug for Password {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Password (*******)")
+        write!(f, "Password {{ bytes: ******* }}")
     }
 }
 
@@ -51,8 +51,7 @@ mod tests {
 
     #[test]
     fn password_obscures_debug() {
-        assert_eq!("Password (*******)", format!("{:?}", password()));
-        assert_eq!("Password (*******)", format!("{:#?}", password()));
+        assert_eq!("Password { bytes: ******* }", format!("{:?}", password()));
     }
 
     #[test]

--- a/src/server/password.rs
+++ b/src/server/password.rs
@@ -1,0 +1,66 @@
+use bytes::Bytes;
+use std::convert;
+use std::fmt;
+
+#[derive(PartialEq, Clone)]
+pub struct Password {
+    bytes: Bytes,
+}
+
+impl Password {
+    pub fn new(bytes: Bytes) -> Self {
+        Password { bytes: bytes }
+    }
+}
+
+impl fmt::Display for Password {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "*******")
+    }
+}
+
+impl fmt::Debug for Password {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Password (*******)")
+    }
+}
+
+impl convert::From<&str> for Password {
+    fn from(s: &str) -> Self {
+        Self::new(s.into())
+    }
+}
+
+impl convert::AsRef<[u8]> for Password {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    const SECRET: &str = "supersecret";
+
+    #[test]
+    fn password_obsures_display() {
+        assert_eq!("*******", format!("{}", password()));
+    }
+
+    #[test]
+    fn password_obscures_debug() {
+        assert_eq!("Password (*******)", format!("{:?}", password()));
+        assert_eq!("Password (*******)", format!("{:#?}", password()));
+    }
+
+    #[test]
+    fn password_retrievable_as_ref() {
+        assert_eq!(SECRET.as_bytes(), password().as_ref())
+    }
+
+    fn password() -> Password {
+        Password::new(SECRET.into())
+    }
+}


### PR DESCRIPTION
This PR wraps the password bytes into a password struct that implements the Display and Debug traits in such a way that it obscures the password when it's being logged.