### PR TITLE
Fixed UTF-8 support (#88).

### DIFF
--- a/src/server/commands/feat.rs
+++ b/src/server/commands/feat.rs
@@ -16,7 +16,7 @@ where
     S::Metadata: storage::Metadata,
 {
     fn execute(&self, args: &CommandArgs<S, U>) -> Result<Reply, FTPError> {
-        let mut feat_text = vec![" SIZE", " MDTM"];
+        let mut feat_text = vec![" SIZE", " MDTM", "UTF8"];
         // Add the features. According to the spec each feature line must be
         // indented by a space.
         if args.tls_configured {

--- a/src/server/commands/mod.rs
+++ b/src/server/commands/mod.rs
@@ -377,7 +377,12 @@ impl Command {
                 }
 
                 match &params[..] {
-                    b"UTF8" => Command::Opts { option: Opt::UTF8 },
+                    b"UTF8 ON" => Command::Opts {
+                        option: Opt::UTF8 { on: true },
+                    },
+                    b"UTF8 OFF" => Command::Opts {
+                        option: Opt::UTF8 { on: false },
+                    },
                     _ => return Err(ParseErrorKind::InvalidCommand.into()),
                 }
             }
@@ -1068,7 +1073,28 @@ mod tests {
         );
 
         let input = "OPTS UTF8\r\n";
-        assert_eq!(Command::parse(input), Ok(Command::Opts { option: Opt::UTF8 }));
+        assert_eq!(
+            Command::parse(input),
+            Err(ParseError {
+                inner: Context::new(ParseErrorKind::InvalidCommand)
+            })
+        );
+
+        let input = "OPTS UTF8 ON\r\n";
+        assert_eq!(
+            Command::parse(input),
+            Ok(Command::Opts {
+                option: Opt::UTF8 { on: true }
+            })
+        );
+
+        let input = "OPTS UTF8 OFF\r\n";
+        assert_eq!(
+            Command::parse(input),
+            Ok(Command::Opts {
+                option: Opt::UTF8 { on: false }
+            })
+        );
     }
 
     #[test]

--- a/src/server/commands/opts.rs
+++ b/src/server/commands/opts.rs
@@ -13,12 +13,12 @@ use crate::server::reply::{Reply, ReplyCode};
 use crate::server::CommandArgs;
 use crate::storage;
 
-/// The parameter that can be given to the `OPTS` command, specifying the option the client wants
+/// The parameters that can be given to the `OPTS` command, specifying the option the client wants
 /// to set.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Opt {
     /// The client wants us to enable UTF-8 encoding for file paths and such.
-    UTF8,
+    UTF8 { on: bool },
 }
 
 pub struct Opts {
@@ -40,7 +40,8 @@ where
 {
     fn execute(&self, _args: &CommandArgs<S, U>) -> Result<Reply, FTPError> {
         match &self.option {
-            Opt::UTF8 => Ok(Reply::new(ReplyCode::FileActionOkay, "Always in UTF-8 mode.")),
+            Opt::UTF8 { on: true } => Ok(Reply::new(ReplyCode::FileActionOkay, "Always in UTF-8 mode.")),
+            Opt::UTF8 { on: false } => Ok(Reply::new(ReplyCode::CommandNotImplementedForParameter, "Non UTF-8 mode not supported")),
         }
     }
 }


### PR DESCRIPTION
This fixes the issue where Filezilla doesn't recognise our UTF-8 support:

See "Filezilla thinks unFTP doesn't support UTF-8 #88"