### PR TITLE
Add a cwd command

### DIFF
--- a/src/server/chancomms.rs
+++ b/src/server/chancomms.rs
@@ -41,6 +41,8 @@ pub enum InternalMsg {
     UnknownRetrieveError,
     /// Listed the directory successfully
     DirectorySuccessfullyListed,
+    /// Successfully cwd
+    CwdSuccess,
     /// File successfully deleted
     DelSuccess,
     /// Failed to delete file

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -566,6 +566,7 @@ where
             DataConnectionClosedAfterStor => Ok(Reply::new(ReplyCode::FileActionOkay, "unFTP holds your data for you")),
             UnknownRetrieveError => Ok(Reply::new(ReplyCode::TransientFileError, "Unknown Error")),
             DirectorySuccessfullyListed => Ok(Reply::new(ReplyCode::ClosingDataConnection, "Listed the directory")),
+            CwdSuccess => Ok(Reply::new(ReplyCode::FileActionOkay, "Successfully cwd")),
             DelSuccess => Ok(Reply::new(ReplyCode::FileActionOkay, "File successfully removed")),
             DelFail => Ok(Reply::new(ReplyCode::TransientFileError, "Failed to delete the file")),
             // The InternalMsg::Quit will never be reached, because we catch it in the task before

--- a/src/storage/filesystem.rs
+++ b/src/storage/filesystem.rs
@@ -292,6 +292,23 @@ impl<U: Send + Sync> StorageBackend<U> for Filesystem {
             }
         }
     }
+
+    async fn cwd<P: AsRef<Path> + Send>(&self, _user: &Option<U>, path: P) -> Result<()> {
+        let full_path = match self.full_path(path) {
+            Ok(path) => path,
+            Err(e) => return Err(e),
+        };
+
+        if let Err(error) = tokio02::fs::read_dir(full_path).await {
+            return Err(match error.kind() {
+                std::io::ErrorKind::NotFound => Error::from(ErrorKind::PermanentFileNotAvailable),
+                std::io::ErrorKind::PermissionDenied => Error::from(ErrorKind::PermissionDenied),
+                _ => Error::from(ErrorKind::LocalError),
+            });
+        }
+
+        Ok(())
+    }
 }
 
 impl Metadata for std::fs::Metadata {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -274,6 +274,9 @@ pub trait StorageBackend<U: Sync + Send> {
 
     /// Delete the given directory.
     async fn rmd<P: AsRef<Path> + Send>(&self, user: &Option<U>, path: P) -> Result<()>;
+
+    /// Cwd the given directory.
+    async fn cwd<P: AsRef<Path> + Send>(&self, user: &Option<U>, path: P) -> Result<()>;
 }
 
 /// StorageBackend that uses a local filesystem, like a traditional FTP server.


### PR DESCRIPTION
Sorry again!

I added the cwd command. This is necessary for uploading folders in Fillezilla.

If OK is returned when CWD command is executed, Fillezilla does not MKD command. If the folder does not exist, Filezilla will execute MKD command if it does not return OK.

