### PR TITLE
Move uris to separate module in GCS backend

### DIFF
--- a/src/storage/cloud_storage/mod.rs
+++ b/src/storage/cloud_storage/mod.rs
@@ -6,11 +6,7 @@ use chrono::{DateTime, Utc};
 use futures::{future, stream, Future, Stream};
 use hyper::{
     client::connect::HttpConnector,
-    http::{
-        header,
-        uri::{Scheme, Uri},
-        Method,
-    },
+    http::{header, Method},
     Body, Chunk, Client, Request, Response,
 };
 use hyper_rustls::HttpsConnector;
@@ -118,15 +114,6 @@ impl CloudStorage {
     fn get_token(&self) -> Box<dyn Future<Item = Token, Error = Error> + Send> {
         Box::new((self.get_token)().map_err(|_| Error::from(ErrorKind::PermanentFileNotAvailable)))
     }
-}
-
-fn make_uri(path_and_query: String) -> Result<Uri, Error> {
-    Uri::builder()
-        .scheme(Scheme::HTTPS)
-        .authority("www.googleapis.com")
-        .path_and_query(path_and_query.as_str())
-        .build()
-        .map_err(|_| Error::from(ErrorKind::FileNameNotAllowedError))
 }
 
 /// The File type for the CloudStorage

--- a/src/storage/cloud_storage/mod.rs
+++ b/src/storage/cloud_storage/mod.rs
@@ -27,7 +27,6 @@ use tokio::{
     codec::{BytesCodec, FramedRead},
     io::AsyncRead,
 };
-use url::percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
 use yup_oauth2::{GetToken, RequestError, ServiceAccountAccess, ServiceAccountKey, Token};
 
 #[derive(Deserialize, Debug)]

--- a/src/storage/cloud_storage/uri.rs
+++ b/src/storage/cloud_storage/uri.rs
@@ -1,0 +1,62 @@
+use crate::storage::{Error, ErrorKind, Fileinfo, Metadata, StorageBackend};
+use hyper::http::uri::Scheme;
+use hyper::Uri;
+use std::path::Path;
+use url::percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
+
+pub struct GcsUri {
+    bucket: String,
+}
+
+impl GcsUri {
+    pub fn new(bucket: String) -> Self {
+        Self { bucket }
+    }
+
+    pub fn metadata<P: AsRef<Path>>(&self, path: P) -> Result<Uri, Error> {
+        make_uri(format!("/storage/v1/b/{}/o/{}", self.bucket, path_str(path)?))
+    }
+
+    pub fn list<P: AsRef<Path>>(&self, path: P) -> Result<Uri, Error> {
+        make_uri(format!("/storage/v1/b/{}/o?delimiter=/&prefix={}", self.bucket, path_str(path)?))
+    }
+
+    pub fn get<P: AsRef<Path>>(&self, path: P) -> Result<Uri, Error> {
+        make_uri(format!("/storage/v1/b/{}/o/{}?alt=media", self.bucket, path_str(path)?))
+    }
+
+    pub fn put<P: AsRef<Path>>(&self, path: P) -> Result<Uri, Error> {
+        let path = path_str(path)?;
+        let path = path.trim_end_matches('/');
+
+        make_uri(format!("/upload/storage/v1/b/{}/o?uploadType=media&name={}", self.bucket, path))
+    }
+
+    pub fn delete<P: AsRef<Path>>(&self, path: P) -> Result<Uri, Error> {
+        make_uri(format!("/storage/v1/b/{}/o/{}", self.bucket, path_str(path)?))
+    }
+
+    pub fn mkd<P: AsRef<Path>>(&self, path: P) -> Result<Uri, Error> {
+        let path = path_str(path)?;
+        let path = path.trim_end_matches('/');
+
+        make_uri(format!("/upload/storage/v1/b/{}/o?uploadType=media&name={}/", self.bucket, path))
+    }
+}
+
+fn make_uri(path_and_query: String) -> Result<Uri, Error> {
+    Uri::builder()
+        .scheme(Scheme::HTTPS)
+        .authority("www.googleapis.com")
+        .path_and_query(path_and_query.as_str())
+        .build()
+        .map_err(|_| Error::from(ErrorKind::FileNameNotAllowedError))
+}
+
+fn path_str<P: AsRef<Path>>(path: P) -> Result<String, Error> {
+    if let Some(path) = path.as_ref().to_str() {
+        Ok(utf8_percent_encode(path, PATH_SEGMENT_ENCODE_SET).collect::<String>())
+    } else {
+        Err(Error::from(ErrorKind::PermanentFileNotAvailable))
+    }
+}

--- a/src/storage/cloud_storage/uri.rs
+++ b/src/storage/cloud_storage/uri.rs
@@ -1,4 +1,4 @@
-use crate::storage::{Error, ErrorKind, Fileinfo, Metadata, StorageBackend};
+use crate::storage::{Error, ErrorKind};
 use hyper::http::uri::Scheme;
 use hyper::Uri;
 use std::path::Path;


### PR DESCRIPTION
This PR aims to DRY up the URI building for the GCS backend.

It also makes sure that all URIs are properly urlencoded.