### PR TITLE
task(gcs): Handle error when metadata cannot be parsed

### DIFF
--- a/src/storage/cloud_storage/mod.rs
+++ b/src/storage/cloud_storage/mod.rs
@@ -384,3 +384,25 @@ fn unpack_response(response: Response<Body>) -> impl Future<Item = Chunk, Error 
             }
         })
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn item_to_metadata_converts() {
+        let sys_time = SystemTime::now();
+        let date_time = DateTime::from(sys_time);
+
+        let item = Item {
+            name: String::from("some_name"),
+            updated: date_time,
+            size: String::from("50"),
+        };
+
+        let metadata = item_to_metadata(item).unwrap();
+        assert_eq!(metadata.size, 50);
+        assert_eq!(metadata.modified().unwrap(), sys_time);
+        assert_eq!(metadata.is_file, true);
+    }
+}


### PR DESCRIPTION
This PR handles some parse errors in the GCS backend. If we encounter an error when we parse the metadata, we will return a TransientFileNotAvailable.

It also removes some duplication, and simplifies some type conversions. Specifically, `item_to_file_info` now uses `item_to_metadata`, and converting between SystemTime and chrono's DateTime now uses chrono's conversion trait.