### PR TITLE
async fn for rmd and rename

### DIFF
--- a/src/server/commands/rmd.rs
+++ b/src/server/commands/rmd.rs
@@ -41,18 +41,16 @@ where
         let path = session.cwd.join(self.path.clone());
         let mut tx_success = args.tx.clone();
         let mut tx_fail = args.tx.clone();
-        if let Some(err) = storage.rmd(&session.user, path).await {
+        if let Err(err) = storage.rmd(&session.user, path).await {
             warn!("Failed to delete directory: {}", err);
             let r = tx_fail.send(InternalMsg::StorageError(err)).await;
-            if r.is_err() {
-                warn!("Could not send internal message to notify of RMD error: {}", r.unwrap_err());
+            if let Err(e) = r {
+                warn!("Could not send internal message to notify of RMD error: {}", e);
             }
         } else {
-            let r = tx_success
-                .send(InternalMsg::DelSuccess)
-                .await;
-            if r.is_err() {
-                warn!("Could not send internal message to notify of RMD success: {}", r.unwrap_err());
+            let r = tx_success.send(InternalMsg::DelSuccess).await;
+            if let Err(e) = r {
+                warn!("Could not send internal message to notify of RMD success: {}", e);
             }
         }
         Ok(Reply::none())

--- a/src/server/commands/rmd.rs
+++ b/src/server/commands/rmd.rs
@@ -12,8 +12,6 @@ use crate::server::reply::Reply;
 use crate::server::CommandArgs;
 use crate::storage;
 use async_trait::async_trait;
-use futures03::channel::mpsc::Sender;
-use futures03::compat::*;
 use futures03::prelude::*;
 use log::warn;
 use std::string::String;
@@ -39,25 +37,24 @@ where
 {
     async fn execute(&self, args: CommandArgs<S, U>) -> Result<Reply, FTPError> {
         let session = args.session.lock().await;
-        let user = session.user.clone();
         let storage: Arc<S> = Arc::clone(&session.storage);
         let path = session.cwd.join(self.path.clone());
-        let mut tx_success: Sender<InternalMsg> = args.tx.clone();
-        let mut tx_fail: Sender<InternalMsg> = args.tx.clone();
-        tokio02::spawn(async move {
-            match storage.rmd(&user, path).compat().await {
-                Ok(_) => {
-                    if let Err(err) = tx_success.send(InternalMsg::DelSuccess).await {
-                        warn!("{}", err);
-                    }
-                }
-                Err(err) => {
-                    if let Err(err) = tx_fail.send(InternalMsg::StorageError(err)).await {
-                        warn!("{}", err);
-                    }
-                }
+        let mut tx_success = args.tx.clone();
+        let mut tx_fail = args.tx.clone();
+        if let Some(err) = storage.rmd(&session.user, path).await {
+            warn!("Failed to delete directory: {}", err);
+            let r = tx_fail.send(InternalMsg::StorageError(err)).await;
+            if r.is_err() {
+                warn!("Could not send internal message to notify of RMD error: {}", r.unwrap_err());
             }
-        });
+        } else {
+            let r = tx_success
+                .send(InternalMsg::DelSuccess)
+                .await;
+            if r.is_err() {
+                warn!("Could not send internal message to notify of RMD success: {}", r.unwrap_err());
+            }
+        }
         Ok(Reply::none())
     }
 }

--- a/src/storage/cloud_storage/mod.rs
+++ b/src/storage/cloud_storage/mod.rs
@@ -376,12 +376,12 @@ impl<U: Sync + Send> StorageBackend<U> for CloudStorage {
         Box::new(result)
     }
 
-    fn rename<P: AsRef<Path>>(&self, _user: &Option<U>, _from: P, _to: P) -> Box<dyn Future<Item = (), Error = Error> + Send> {
+    async fn rename<P: AsRef<Path> + Send>(&self, _user: &Option<U>, _from: P, _to: P) -> super::Result<()> {
         //TODO: implement this
         unimplemented!();
     }
 
-    async fn rmd<P: AsRef<Path> + Send>(&self, _user: &Option<U>, _path: P) -> Option<Error> {
+    async fn rmd<P: AsRef<Path> + Send>(&self, _user: &Option<U>, _path: P) -> super::Result<()> {
         //TODO: implement this
         unimplemented!();
     }

--- a/src/storage/cloud_storage/mod.rs
+++ b/src/storage/cloud_storage/mod.rs
@@ -2,6 +2,7 @@ mod uri;
 
 use crate::storage::{AsAsyncReads, Error, ErrorKind, Fileinfo, Metadata, StorageBackend};
 
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::{future, stream, Future, Stream};
 use hyper::{
@@ -201,6 +202,7 @@ impl Metadata for ObjectMetadata {
     }
 }
 
+#[async_trait]
 impl<U: Sync + Send> StorageBackend<U> for CloudStorage {
     type File = Object;
     type Metadata = ObjectMetadata;
@@ -379,7 +381,7 @@ impl<U: Sync + Send> StorageBackend<U> for CloudStorage {
         unimplemented!();
     }
 
-    fn rmd<P: AsRef<Path>>(&self, _user: &Option<U>, _path: P) -> Box<dyn Future<Item = (), Error = Error> + Send> {
+    async fn rmd<P: AsRef<Path> + Send>(&self, _user: &Option<U>, _path: P) -> Option<Error> {
         //TODO: implement this
         unimplemented!();
     }

--- a/src/storage/filesystem.rs
+++ b/src/storage/filesystem.rs
@@ -223,21 +223,21 @@ impl<U: Send + Sync> StorageBackend<U> for Filesystem {
         Box::new(fut01)
     }
 
-    async fn rmd<P: AsRef<Path> + Send>(&self, _user: &Option<U>, path: P) -> Option<Error> {
+    async fn rmd<P: AsRef<Path> + Send>(&self, _user: &Option<U>, path: P) -> Result<()> {
         let full_path = match self.full_path(path) {
             Ok(path) => path,
-            Err(e) => return Some(e),
+            Err(e) => return Err(e),
         };
 
         if let Err(error) = tokio02::fs::remove_dir(full_path).await {
-            return Some(match error.kind() {
+            return Err(match error.kind() {
                 std::io::ErrorKind::NotFound => Error::from(ErrorKind::PermanentFileNotAvailable),
                 std::io::ErrorKind::PermissionDenied => Error::from(ErrorKind::PermissionDenied),
                 _ => Error::from(ErrorKind::LocalError),
             });
         }
 
-        return None;
+        Ok(())
     }
 
     fn mkd<P: AsRef<Path>>(&self, _user: &Option<U>, path: P) -> Box<dyn Future<Item = (), Error = Error> + Send> {
@@ -258,45 +258,39 @@ impl<U: Send + Sync> StorageBackend<U> for Filesystem {
         Box::new(fut01)
     }
 
-    fn rename<P: AsRef<Path>>(&self, _user: &Option<U>, from: P, to: P) -> Box<dyn Future<Item = (), Error = Error> + Send> {
+    async fn rename<P: AsRef<Path> + Send>(&self, _user: &Option<U>, from: P, to: P) -> Result<()> {
         let from = match self.full_path(from) {
             Ok(path) => path,
-            Err(e) => return Box::new(future::err(e)),
+            Err(e) => return Err(e),
         };
         let to = match self.full_path(to) {
             Ok(path) => path,
-            Err(e) => return Box::new(future::err(e)),
+            Err(e) => return Err(e),
         };
 
         let from_rename = from.clone();
 
-        let fut01 = async move {
-            let r = tokio02::fs::symlink_metadata(from).await;
-            match r {
-                Ok(metadata) => {
-                    if metadata.is_file() {
-                        let r = tokio02::fs::rename(from_rename, to).await;
-                        match r {
-                            Ok(_) => Ok(()),
-                            Err(e) => {
-                                warn!("could not rename file: {:?}", e);
-                                Err(Error::from(ErrorKind::PermanentFileNotAvailable))
-                            }
+        let r = tokio02::fs::symlink_metadata(from).await;
+        match r {
+            Ok(metadata) => {
+                if metadata.is_file() {
+                    let r = tokio02::fs::rename(from_rename, to).await;
+                    match r {
+                        Ok(_) => Ok(()),
+                        Err(e) => {
+                            warn!("could not rename file: {:?}", e);
+                            Err(Error::from(ErrorKind::PermanentFileNotAvailable))
                         }
-                    } else {
-                        Err(Error::from(ErrorKind::PermanentFileNotAvailable))
                     }
-                }
-                Err(e) => {
-                    warn!("could not get file metadata: {:?}", e);
+                } else {
                     Err(Error::from(ErrorKind::PermanentFileNotAvailable))
                 }
             }
+            Err(e) => {
+                warn!("could not get file metadata: {:?}", e);
+                Err(Error::from(ErrorKind::PermanentFileNotAvailable))
+            }
         }
-        .boxed()
-        .compat();
-
-        Box::new(fut01)
     }
 }
 
@@ -541,8 +535,8 @@ mod tests {
         let mut rt = CompatRuntime::new().unwrap();
 
         let fs = Filesystem::new(&root);
-        rt.block_on(fs.rename(&Some(AnonymousUser {}), &old_filename, &new_filename))
-            .expect("Failed to rename");
+        let r = rt.block_on_std(fs.rename(&Some(AnonymousUser {}), &old_filename, &new_filename));
+        assert!(r.is_ok());
 
         let new_full_path = root.join(new_filename);
         assert!(std::fs::metadata(new_full_path).expect("new filename not found").is_file());

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -270,10 +270,10 @@ pub trait StorageBackend<U: Sync + Send> {
     fn mkd<P: AsRef<Path>>(&self, user: &Option<U>, path: P) -> Box<dyn Future<Item = (), Error = Error> + Send>;
 
     /// Rename the given file to the given filename.
-    fn rename<P: AsRef<Path>>(&self, user: &Option<U>, from: P, to: P) -> Box<dyn Future<Item = (), Error = Error> + Send>;
+    async fn rename<P: AsRef<Path> + Send>(&self, user: &Option<U>, from: P, to: P) -> Result<()>;
 
     /// Delete the given directory.
-    async fn rmd<P: AsRef<Path> + Send>(&self, user: &Option<U>, path: P) -> Option<Error>;
+    async fn rmd<P: AsRef<Path> + Send>(&self, user: &Option<U>, path: P) -> Result<()>;
 }
 
 /// StorageBackend that uses a local filesystem, like a traditional FTP server.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7,6 +7,7 @@ use std::{
     result,
 };
 
+use async_trait::async_trait;
 use chrono::prelude::{DateTime, Utc};
 use failure::{Backtrace, Context, Fail};
 use futures::{Future, Stream};
@@ -182,7 +183,8 @@ pub trait AsAsyncReads {
 ///
 /// [`Server`]: ../server/struct.Server.html
 /// [`filesystem`]: ./struct.Filesystem.html
-pub trait StorageBackend<U: Sync + Send>: Send + Sync {
+#[async_trait]
+pub trait StorageBackend<U: Sync + Send> {
     /// The concrete type of the Files returned by this StorageBackend.
     type File: AsAsyncReads + Sync + Send;
     /// The concrete type of the `Metadata` used by this StorageBackend.
@@ -271,7 +273,7 @@ pub trait StorageBackend<U: Sync + Send>: Send + Sync {
     fn rename<P: AsRef<Path>>(&self, user: &Option<U>, from: P, to: P) -> Box<dyn Future<Item = (), Error = Error> + Send>;
 
     /// Delete the given directory.
-    fn rmd<P: AsRef<Path>>(&self, user: &Option<U>, path: P) -> Box<dyn Future<Item = (), Error = Error> + Send>;
+    async fn rmd<P: AsRef<Path> + Send>(&self, user: &Option<U>, path: P) -> Option<Error>;
 }
 
 /// StorageBackend that uses a local filesystem, like a traditional FTP server.


### PR DESCRIPTION
This MR converts the `remove dir` and `rename` commands in the storage backends to async/.await.

This also 
- Fixes: #75 
- Contributes towards #120 
- Contributes towards  #70
