### PR TITLE
Got rid of futures 0.1 dependency in session.rs and converted the mai…

### DIFF
--- a/src/server/chancomms.rs
+++ b/src/server/chancomms.rs
@@ -5,7 +5,7 @@ use crate::server::reply::ReplyCode;
 use crate::storage::Error;
 
 // Commands that can be send to the data channel.
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub enum DataCommand {
     ExternalCommand(Command),
     Abort,

--- a/src/server/commands/pasv.rs
+++ b/src/server/commands/pasv.rs
@@ -99,14 +99,14 @@ where
 
         let session = args.session.clone();
 
+        // Open the data connection in a new task and process it.
+        // We cannot await this since we first need to let the client know where to connect :-)
         tokio02::spawn(async move {
             if let Ok((socket, _socket_addr)) = listener.accept().await {
                 let tx = tx.clone();
                 let session_arc = session.clone();
                 let mut session = session_arc.lock().await;
-                let user = session.user.clone();
-                let tls = session.data_tls;
-                session.process_data(user, socket, tls, tx);
+                session.spawn_data_processing(socket, tx);
             }
         });
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -255,15 +255,15 @@ where
         loop {
             let (tcp_stream, socket_addr) = listener.accept().await.unwrap();
             info!("Incoming control channel connection from {:?}", socket_addr);
-            let result = self.process_control_connection(tcp_stream).await;
+            let result = self.spawn_control_channel_loop(tcp_stream).await;
             if result.is_err() {
-                warn!("Could not process connection: {:?}", result.err().unwrap())
+                warn!("Could not spawn control channel loop for connection: {:?}", result.err().unwrap())
             }
         }
     }
 
     /// Does TCP processing when a FTP client connects
-    async fn process_control_connection(&self, tcp_stream: tokio02::net::TcpStream) -> Result<(), FTPError> {
+    async fn spawn_control_channel_loop(&self, tcp_stream: tokio02::net::TcpStream) -> Result<(), FTPError> {
         let with_metrics = self.with_metrics;
         let tls_configured = if let (Some(_), Some(_)) = (&self.certs_file, &self.certs_password) {
             true


### PR DESCRIPTION
…n combinator to async/.await (#70,#120)

This is a refactoring that:
- Contributes towards #120
- Contributes towards #70

tokio 0.1 is not used anymore to spawn data channel processing (now tokio 0.2) and futures 0.1 is also replaced with futures 0.2. We still have a dependency on tokio 0.1. for its `copy` method. To change that we have to convert the storage back-ends to async/.await and/or use tokio-compat.

In this MR I convert the combinator style of spawning the data channel processing (old `process_data `) to async/await through the use of the `select!` macro of tokio and then split the handling abort and the other commands apart by putting the command handling code in its own struct namely the `DataCommandExecutor ` struct. It looks like a lot of new code but a lot was just moved around a bit. 