### PR TITLE
Cleanup of data channel handler code

### DIFF
--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -38,126 +38,142 @@ where
     pub async fn execute(self, cmd: Command) {
         match cmd {
             Command::Retr { path } => {
-                let path = self.cwd.join(path);
-                let mut tx_sending: Sender<InternalMsg> = self.tx.clone();
-                let mut tx_error: Sender<InternalMsg> = self.tx.clone();
-                tokio::spawn(async move {
-                    match self.storage.get(&self.user, path, self.start_pos).await {
-                        Ok(f) => match tx_sending.send(InternalMsg::SendingData).await {
-                            Ok(_) => {
-                                let mut input = f.as_tokio02_async_read();
-                                let mut output = Self::writer(self.socket, self.tls, self.identity_file, self.identity_password);
-                                match tokio::io::copy(&mut input, &mut output).await {
-                                    Ok(bytes_copied) => {
-                                        if let Err(err) = output.shutdown().await {
-                                            warn!("Could not shutdown output stream after RETR: {}", err);
-                                        }
-                                        if let Err(err) = tx_sending.send(InternalMsg::SendData { bytes: bytes_copied as i64 }).await {
-                                            warn!("Could not notify control channel of successful RETR: {}", err);
-                                        }
-                                    }
-                                    Err(err) => warn!("Error copying streams during RETR: {}", err),
-                                }
-                            }
-                            Err(err) => warn!("Error notifying control channel of progress during RETR: {}", err),
-                        },
-                        Err(err) => {
-                            if let Err(err) = tx_error.send(InternalMsg::StorageError(err)).await {
-                                warn!("Could not notify control channel of error with RETR: {}", err);
-                            }
-                        }
-                    }
-                });
+                self.exec_retr(path).await;
             }
             Command::Stor { path } => {
-                let path = self.cwd.join(path);
-                let mut tx_ok = self.tx.clone();
-                let mut tx_error = self.tx.clone();
-                tokio::spawn(async move {
-                    match self
-                        .storage
-                        .put(
-                            &self.user,
-                            Self::reader(self.socket, self.tls, self.identity_file, self.identity_password),
-                            path,
-                            self.start_pos,
-                        )
-                        .await
-                    {
-                        Ok(bytes) => {
-                            if let Err(err) = tx_ok.send(InternalMsg::WrittenData { bytes: bytes as i64 }).await {
-                                warn!("Could not notify control channel of successful STOR: {}", err);
-                            }
-                        }
-                        Err(err) => {
-                            if let Err(err) = tx_error.send(InternalMsg::StorageError(err)).await {
-                                warn!("Could not notify control channel of error with STOR: {}", err);
-                            }
-                        }
-                    }
-                });
+                self.exec_stor(path).await;
             }
             Command::List { path, .. } => {
-                let path = match path {
-                    Some(path) => self.cwd.join(path),
-                    None => self.cwd.clone(),
-                };
-                let mut tx_ok = self.tx.clone();
-                tokio::spawn(async move {
-                    match self.storage.list_fmt(&self.user, path).await {
-                        Ok(cursor) => {
-                            debug!("Copying future for List");
-                            let mut input = cursor;
-                            let mut output = Self::writer(self.socket, self.tls, self.identity_file, self.identity_password);
-                            match tokio::io::copy(&mut input, &mut output).await {
-                                Ok(_) => {
-                                    if let Err(err) = output.shutdown().await {
-                                        warn!("Could not shutdown output stream during LIST: {}", err);
-                                    }
-                                    if let Err(err) = tx_ok.send(InternalMsg::DirectorySuccessfullyListed).await {
-                                        warn!("Could not notify control channel of successful LIST: {}", err);
-                                    }
-                                }
-                                Err(err) => warn!("Could not copy from storage implementation during LIST: {}", err),
-                            }
-                        }
-                        Err(err) => warn!("Failed to send directory list: {:?}", err),
-                    }
-                });
+                self.exec_list(path).await;
             }
             Command::Nlst { path } => {
-                let path = match path {
-                    Some(path) => self.cwd.join(path),
-                    None => self.cwd.clone(),
-                };
-                let mut tx_ok = self.tx.clone();
-                let mut tx_error = self.tx.clone();
-                tokio::spawn(async move {
-                    match self.storage.nlst(&self.user, path).await {
-                        Ok(mut input) => {
-                            let mut output = Self::writer(self.socket, self.tls, self.identity_file, self.identity_password);
-                            match tokio::io::copy(&mut input, &mut output).await {
-                                Ok(_) => {
-                                    if let Err(err) = output.shutdown().await {
-                                        warn!("Could not shutdown output stream during NLIST: {}", err);
-                                    }
-                                    if let Err(err) = tx_ok.send(InternalMsg::DirectorySuccessfullyListed).await {
-                                        warn!("Could not notify control channel of successful NLIST: {}", err);
-                                    }
-                                }
-                                Err(err) => warn!("Could not copy from storage implementation during NLST: {}", err),
-                            }
-                        }
-                        Err(_) => {
-                            if let Err(err) = tx_error.send(InternalMsg::StorageError(Error::from(ErrorKind::LocalError))).await {
-                                warn!("Could not notify control channel of error with NLIST: {}", err);
-                            }
-                        }
-                    }
-                });
+                self.exec_nlst(path).await;
             }
             _ => unimplemented!(),
         }
+    }
+
+    async fn exec_retr(self, path: String) {
+        let path = self.cwd.join(path);
+        let mut tx_sending: Sender<InternalMsg> = self.tx.clone();
+        let mut tx_error: Sender<InternalMsg> = self.tx.clone();
+        tokio::spawn(async move {
+            match self.storage.get(&self.user, path, self.start_pos).await {
+                Ok(f) => match tx_sending.send(InternalMsg::SendingData).await {
+                    Ok(_) => {
+                        let mut input = f.as_tokio02_async_read();
+                        let mut output = Self::writer(self.socket, self.tls, self.identity_file, self.identity_password);
+                        match tokio::io::copy(&mut input, &mut output).await {
+                            Ok(bytes_copied) => {
+                                if let Err(err) = output.shutdown().await {
+                                    warn!("Could not shutdown output stream after RETR: {}", err);
+                                }
+                                if let Err(err) = tx_sending.send(InternalMsg::SendData { bytes: bytes_copied as i64 }).await {
+                                    warn!("Could not notify control channel of successful RETR: {}", err);
+                                }
+                            }
+                            Err(err) => warn!("Error copying streams during RETR: {}", err),
+                        }
+                    }
+                    Err(err) => warn!("Error notifying control channel of progress during RETR: {}", err),
+                },
+                Err(err) => {
+                    if let Err(err) = tx_error.send(InternalMsg::StorageError(err)).await {
+                        warn!("Could not notify control channel of error with RETR: {}", err);
+                    }
+                }
+            }
+        });
+    }
+
+    async fn exec_stor(self, path: String) {
+        let path = self.cwd.join(path);
+        let mut tx_ok = self.tx.clone();
+        let mut tx_error = self.tx.clone();
+        tokio::spawn(async move {
+            match self
+                .storage
+                .put(
+                    &self.user,
+                    Self::reader(self.socket, self.tls, self.identity_file, self.identity_password),
+                    path,
+                    self.start_pos,
+                )
+                .await
+            {
+                Ok(bytes) => {
+                    if let Err(err) = tx_ok.send(InternalMsg::WrittenData { bytes: bytes as i64 }).await {
+                        warn!("Could not notify control channel of successful STOR: {}", err);
+                    }
+                }
+                Err(err) => {
+                    if let Err(err) = tx_error.send(InternalMsg::StorageError(err)).await {
+                        warn!("Could not notify control channel of error with STOR: {}", err);
+                    }
+                }
+            }
+        });
+    }
+
+    async fn exec_list(self, path: Option<String>) {
+        let path = match path {
+            Some(path) => self.cwd.join(path),
+            None => self.cwd.clone(),
+        };
+        let mut tx_ok = self.tx.clone();
+        tokio::spawn(async move {
+            match self.storage.list_fmt(&self.user, path).await {
+                Ok(cursor) => {
+                    debug!("Copying future for List");
+                    let mut input = cursor;
+                    let mut output = Self::writer(self.socket, self.tls, self.identity_file, self.identity_password);
+                    match tokio::io::copy(&mut input, &mut output).await {
+                        Ok(_) => {
+                            if let Err(err) = output.shutdown().await {
+                                warn!("Could not shutdown output stream during LIST: {}", err);
+                            }
+                            if let Err(err) = tx_ok.send(InternalMsg::DirectorySuccessfullyListed).await {
+                                warn!("Could not notify control channel of successful LIST: {}", err);
+                            }
+                        }
+                        Err(err) => warn!("Could not copy from storage implementation during LIST: {}", err),
+                    }
+                }
+                Err(err) => warn!("Failed to send directory list: {:?}", err),
+            }
+        });
+    }
+
+    async fn exec_nlst(self, path: Option<String>) {
+        let path = match path {
+            Some(path) => self.cwd.join(path),
+            None => self.cwd.clone(),
+        };
+        let mut tx_ok = self.tx.clone();
+        let mut tx_error = self.tx.clone();
+        tokio::spawn(async move {
+            match self.storage.nlst(&self.user, path).await {
+                Ok(mut input) => {
+                    let mut output = Self::writer(self.socket, self.tls, self.identity_file, self.identity_password);
+                    match tokio::io::copy(&mut input, &mut output).await {
+                        Ok(_) => {
+                            if let Err(err) = output.shutdown().await {
+                                warn!("Could not shutdown output stream during NLIST: {}", err);
+                            }
+                            if let Err(err) = tx_ok.send(InternalMsg::DirectorySuccessfullyListed).await {
+                                warn!("Could not notify control channel of successful NLIST: {}", err);
+                            }
+                        }
+                        Err(err) => warn!("Could not copy from storage implementation during NLST: {}", err),
+                    }
+                }
+                Err(_) => {
+                    if let Err(err) = tx_error.send(InternalMsg::StorageError(Error::from(ErrorKind::LocalError))).await {
+                        warn!("Could not notify control channel of error with NLIST: {}", err);
+                    }
+                }
+            }
+        });
     }
 
     // Lots of code duplication here. Should disappear completely when the storage backends are rewritten in async/.await style


### PR DESCRIPTION
This PR is based on top of the changes for #161, so that should be merged first.

This PR splits the data channel command handler into smaller methods for better maintainability.