### PR TITLE
Renamed methods for consistency and adherence to rust conventions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ use tokio::prelude::*;
 #[tokio::main]
 pub async fn main() {
     let ftp_home = std::env::temp_dir();
-    let server = libunftp::Server::with_root(ftp_home)
+    let server = libunftp::Server::new_with_fs_root(ftp_home)
         .greeting("Welcome to my FTP server")
         .passive_ports(50000..65535);
 
-    server.listener("127.0.0.1:2121");
+    server.listen("127.0.0.1:2121");
 }
 ```
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,8 +6,8 @@ pub async fn main() {
     pretty_env_logger::init();
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::with_root(std::env::temp_dir());
+    let server = libunftp::Server::new_with_fs_root(std::env::temp_dir());
 
     info!("Starting ftp server on {}", addr);
-    server.listener(addr).await;
+    server.listen(addr).await;
 }

--- a/examples/gcs.rs
+++ b/examples/gcs.rs
@@ -14,6 +14,6 @@ pub fn main() -> std::io::Result<()> {
     }));
 
     info!("Starting ftp server on {}", addr);
-    runtime.block_on(server.listener(addr));
+    runtime.block_on(server.listen(addr));
     Ok(())
 }

--- a/examples/jsonfile_auth.rs
+++ b/examples/jsonfile_auth.rs
@@ -10,11 +10,11 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let authenticator = jsonfile::JsonFileAuthenticator::new(String::from("credentials.json"))?;
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::with_root(std::env::temp_dir()).authenticator(Arc::new(authenticator));
+    let server = libunftp::Server::new_with_fs_root(std::env::temp_dir()).authenticator(Arc::new(authenticator));
 
     info!("Starting ftp server on {}", addr);
     let mut runtime = tokio::runtime::Builder::new().build().unwrap();
-    runtime.block_on(server.listener(addr));
+    runtime.block_on(server.listen(addr));
 
     Ok(())
 }

--- a/examples/pam.rs
+++ b/examples/pam.rs
@@ -11,8 +11,8 @@ pub fn main() {
     info!("Starting ftp server on {}", addr);
     let authenticator = pam::PAMAuthenticator::new("hello");
 
-    let server = libunftp::Server::with_root(std::env::temp_dir()).authenticator(Arc::new(authenticator));
+    let server = libunftp::Server::new_with_fs_root(std::env::temp_dir()).authenticator(Arc::new(authenticator));
 
     let mut runtime = tokio::runtime::Builder::new().build().unwrap();
-    runtime.block_on(server.listener(addr));
+    runtime.block_on(server.listen(addr));
 }

--- a/examples/rest.rs
+++ b/examples/rest.rs
@@ -20,10 +20,10 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::with_root(std::env::temp_dir()).authenticator(Arc::new(authenticator));
+    let server = libunftp::Server::new_with_fs_root(std::env::temp_dir()).authenticator(Arc::new(authenticator));
 
     info!("Starting ftp server on {}", addr);
     let mut runtime = Builder::new().build()?;
-    runtime.block_on(server.listener(addr));
+    runtime.block_on(server.listen(addr));
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,11 @@
 //!
 //! ```rust
 //!  let ftp_home = std::env::temp_dir();
-//!  let server = libunftp::Server::with_root(ftp_home)
+//!  let server = libunftp::Server::new_with_fs_root(ftp_home)
 //!    .greeting("Welcome to my FTP server")
 //!    .passive_ports(50000..65535);
 //!
-//!  server.listener("127.0.0.1:2121");
+//!  server.listen("127.0.0.1:2121");
 //! ```
 
 pub mod auth;

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -44,7 +44,7 @@ where
     pub cmd_tls: bool,
     // True if the data channel is in secure mode.
     pub data_tls: bool,
-    pub with_metrics: bool,
+    pub collect_metrics: bool,
     // The starting byte for a STOR or RETR command. Set by the _Restart of Interrupted Transfer (REST)_
     // command to support resume functionality.
     pub start_pos: u64,
@@ -56,7 +56,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    pub(super) fn with_storage(storage: Arc<S>) -> Self {
+    pub(super) fn new(storage: Arc<S>) -> Self {
         Session {
             user: Arc::new(None),
             username: None,
@@ -72,22 +72,22 @@ where
             certs_password: Option::None,
             cmd_tls: false,
             data_tls: false,
-            with_metrics: false,
+            collect_metrics: false,
             start_pos: 0,
         }
     }
 
-    pub(super) fn with_ftps(mut self, certs_file: Option<PathBuf>, password: Option<String>) -> Self {
+    pub(super) fn ftps(mut self, certs_file: Option<PathBuf>, password: Option<String>) -> Self {
         self.certs_file = certs_file;
         self.certs_password = password;
         self
     }
 
-    pub(super) fn with_metrics(mut self, with_metrics: bool) -> Self {
-        if with_metrics {
+    pub(super) fn metrics(mut self, collect_metrics: bool) -> Self {
+        if collect_metrics {
             metrics::inc_session();
         }
-        self.with_metrics = with_metrics;
+        self.collect_metrics = collect_metrics;
         self
     }
 
@@ -157,7 +157,7 @@ where
     S::Metadata: storage::Metadata,
 {
     fn drop(&mut self) {
-        if self.with_metrics {
+        if self.collect_metrics {
             // Decrease the sessions metrics gauge when the session goes out of scope.
             metrics::dec_session();
         }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -12,8 +12,8 @@ use tokio::runtime::Runtime;
 
 fn test_with(addr: &'static str, path: impl Into<PathBuf> + Send, test: impl FnOnce() -> ()) {
     let rt = Runtime::new().unwrap();
-    let server = libunftp::Server::with_root(path.into());
-    let _thread = rt.spawn(server.listener(addr));
+    let server = libunftp::Server::new_with_fs_root(path.into());
+    let _thread = rt.spawn(server.listen(addr));
     std::thread::sleep(Duration::new(1, 0));
     test();
 }


### PR DESCRIPTION
After reading the [Rust API Guidelines checklist](https://rust-lang.github.io/api-guidelines/checklist.html) it inspired me to do some name changes to our public API.