### PR TITLE
Don't expose error types

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,7 +4,7 @@ mod chancomms;
 mod commands;
 mod controlchan;
 mod datachan;
-pub mod error;
+pub(crate) mod error;
 pub(crate) mod ftpserver;
 mod io;
 mod password;


### PR DESCRIPTION
Unless I'm missing something there is no use in exposing this in the API at the moment.