### PR TITLE
use environment variables to configure the gcs example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ ftp = "3.0.1"
 pretty_env_logger = "0.4.0"
 pretty_assertions = "0.6.1"
 tokio = { version = "0.2.17", features = ["rt-threaded"]}
+clap = "2.33.0"
 
 [features]
 pam_auth = ["pam-auth"]

--- a/examples/gcs.rs
+++ b/examples/gcs.rs
@@ -1,19 +1,48 @@
-use log::*;
+use clap::{App, Arg};
+use std::{error::Error, result::Result};
 
-pub fn main() -> std::io::Result<()> {
-    pretty_env_logger::init();
+const BUCKET_NAME: &str = "bucket-name";
+const SERVICE_ACCOUNT_KEY: &str = "service-account-key";
 
-    let addr = "127.0.0.1:2121";
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn Error>> {
+    let matches = App::new("Example for using libunftp with Google Cloud Storage backend")
+        .about("An FTP server that uses Google Cloud Storage as a backend")
+        .author("The bol.com unFTP team")
+        .arg(
+            Arg::with_name(BUCKET_NAME)
+                .short("b")
+                .long(BUCKET_NAME)
+                .value_name("BUCKET_NAME")
+                .env("LIBUNFTP_BUCKET_NAME")
+                .help("The name of the Google Cloud Storage bucket to be used")
+                .required(true),
+        )
+        .arg(
+            Arg::with_name(SERVICE_ACCOUNT_KEY)
+                .short("s")
+                .long(SERVICE_ACCOUNT_KEY)
+                .value_name("SERVICE_ACCOUNT_KEY")
+                .env("LIBUNFTP_SERVICE_ACCOUNT_KEY")
+                .help("The service account key JSON file of the Google Cloud Storage bucket to be used")
+                .required(true),
+        )
+        .get_matches();
 
-    let mut runtime = tokio::runtime::Builder::new().build()?;
+    let service_account_key = matches
+        .value_of(SERVICE_ACCOUNT_KEY)
+        .ok_or_else(|| "Internal error: use of an undefined command line parameter")?;
+    let bucket_name = matches
+        .value_of(BUCKET_NAME)
+        .ok_or_else(|| "Internal error: use of an undefined command line parameter")?
+        .to_owned();
 
-    let service_account_key = runtime.block_on(yup_oauth2::read_service_account_key(&"key.json".to_string()))?;
+    let service_account_key = yup_oauth2::read_service_account_key(service_account_key).await?;
 
     let server = libunftp::Server::new(Box::new(move || {
-        libunftp::storage::cloud_storage::CloudStorage::new("my-bucket", service_account_key.clone())
+        libunftp::storage::cloud_storage::CloudStorage::new(&bucket_name, service_account_key.clone())
     }));
 
-    info!("Starting ftp server on {}", addr);
-    runtime.block_on(server.listen(addr));
+    server.listen("127.0.0.1:2121").await;
     Ok(())
 }

--- a/src/storage/cloud_storage/mod.rs
+++ b/src/storage/cloud_storage/mod.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use bytes::{buf::BufExt, Buf};
 use chrono::{DateTime, Utc};
 use futures::prelude::*;
-use http::{StatusCode, Uri};
+use hyper::http::{StatusCode, Uri};
 use hyper::{
     body::aggregate,
     client::connect::{dns::GaiResolver, HttpConnector},


### PR DESCRIPTION
Make the gcs example configurable for easier development:
use either command line arguments to set the bucket name and the service account key, or environment variables