### PR TITLE
Moved server::error to server::controlchan::error

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Contains the `add...metric` functions that are used for gathering metrics.
 
-use crate::server::{Command, Event, FTPErrorKind, InternalMsg, Reply, ReplyCode};
+use crate::server::{Command, ControlChanErrorKind, Event, InternalMsg, Reply, ReplyCode};
 
 use lazy_static::*;
 use prometheus::{opts, register_int_counter, register_int_counter_vec, register_int_gauge, IntCounter, IntCounterVec, IntGauge};
@@ -53,7 +53,7 @@ pub fn dec_session() {
 }
 
 /// Add a metric for an FTP server error.
-pub fn add_error_metric(error: &FTPErrorKind) {
+pub fn add_error_metric(error: &ControlChanErrorKind) {
     let error_str = error.to_string();
     let label = error_str.split_whitespace().next().unwrap_or("unknown").to_lowercase();
     FTP_ERROR_TOTAL.with_label_values(&[&label]).inc();

--- a/src/server/controlchan/codecs.rs
+++ b/src/server/controlchan/codecs.rs
@@ -1,6 +1,6 @@
 use super::command::Command;
+use super::error::ControlChanError;
 use super::Reply;
-use crate::server::FTPError;
 
 use bytes::BytesMut;
 use std::io::Write;
@@ -24,7 +24,7 @@ impl FTPCodec {
 
 impl Decoder for FTPCodec {
     type Item = Command;
-    type Error = FTPError;
+    type Error = ControlChanError;
 
     // Here we decode the incoming bytes into a meaningful command. We'll split on newlines, and
     // parse the resulting line using `Command::parse()`. This method will be called by tokio.
@@ -42,7 +42,7 @@ impl Decoder for FTPCodec {
 }
 
 impl Encoder<Reply> for FTPCodec {
-    type Error = FTPError;
+    type Error = ControlChanError;
 
     // Here we encode the outgoing response
     fn encode(&mut self, reply: Reply, buf: &mut BytesMut) -> Result<(), Self::Error> {

--- a/src/server/controlchan/commands/abor.rs
+++ b/src/server/controlchan/commands/abor.rs
@@ -9,9 +9,9 @@
 // connection is not to be closed by the server, but the data
 // connection must be closed.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::{CommandContext, CommandHandler};
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::prelude::*;
@@ -27,7 +27,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         match session.data_abort_tx.take() {
             Some(mut tx) => {

--- a/src/server/controlchan/commands/acct.rs
+++ b/src/server/controlchan/commands/acct.rs
@@ -17,10 +17,10 @@
 // (pending receipt of the ACCounT command) or discards the
 // command, respectively.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -34,7 +34,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         Ok(Reply::new(ReplyCode::NotLoggedIn, "Rejected"))
     }
 }

--- a/src/server/controlchan/commands/allo.rs
+++ b/src/server/controlchan/commands/allo.rs
@@ -18,10 +18,10 @@
 // the maximum record or page size should accept a dummy value
 // in the first argument and ignore it.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -35,7 +35,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         // ALLO is obsolete and we'll just ignore it.
         Ok(Reply::new(ReplyCode::CommandOkayNotImplemented, "Ignored"))
     }

--- a/src/server/controlchan/commands/auth.rs
+++ b/src/server/controlchan/commands/auth.rs
@@ -5,10 +5,10 @@
 //! commands.
 
 use crate::server::chancomms::InternalMsg;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::prelude::*;
@@ -39,7 +39,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut tx = args.tx.clone();
         match (args.tls_configured, self.protocol.clone()) {
             (true, AuthParam::Tls) => {

--- a/src/server/controlchan/commands/ccc.rs
+++ b/src/server/controlchan/commands/ccc.rs
@@ -1,10 +1,10 @@
 //! The RFC 2228 Clear Command Channel (`CCC`) command
 
 use crate::server::chancomms::InternalMsg;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::channel::mpsc::Sender;
@@ -20,7 +20,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut tx: Sender<InternalMsg> = args.tx.clone();
         let session = args.session.lock().await;
         if session.cmd_tls {

--- a/src/server/controlchan/commands/cdup.rs
+++ b/src/server/controlchan/commands/cdup.rs
@@ -6,10 +6,10 @@
 // syntaxes for naming the parent directory.  The reply codes
 // shall be identical to the reply codes of CWD.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -23,7 +23,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         session.cwd.pop();
         Ok(Reply::new(ReplyCode::FileActionOkay, "OK"))

--- a/src/server/controlchan/commands/cwd.rs
+++ b/src/server/controlchan/commands/cwd.rs
@@ -8,10 +8,10 @@
 // file group designator.
 
 use crate::server::chancomms::InternalMsg;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::Reply;
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::prelude::*;
@@ -37,7 +37,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         let storage: Arc<S> = Arc::clone(&session.storage);
         let path = session.cwd.join(self.path.clone());

--- a/src/server/controlchan/commands/dele.rs
+++ b/src/server/controlchan/commands/dele.rs
@@ -6,10 +6,10 @@
 // it should be provided by the user-FTP process.
 
 use crate::server::chancomms::InternalMsg;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::Reply;
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::channel::mpsc::Sender;
@@ -36,7 +36,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let session = args.session.lock().await;
         let storage = Arc::clone(&session.storage);
         let user = session.user.clone();

--- a/src/server/controlchan/commands/feat.rs
+++ b/src/server/controlchan/commands/feat.rs
@@ -1,9 +1,9 @@
 //! The RFC 2389 Feature (`FEAT`) command
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -17,7 +17,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut feat_text = vec![" SIZE", " MDTM", "UTF8"];
         // Add the features. According to the spec each feature line must be
         // indented by a space.

--- a/src/server/controlchan/commands/help.rs
+++ b/src/server/controlchan/commands/help.rs
@@ -5,10 +5,10 @@
 // A HELP request may include a parameter. The meaning of the parameter is defined by the server. Some servers interpret the parameter as an FTP verb,
 // and respond by briefly explaining the syntax of the verb.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -22,7 +22,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let text = vec!["Help:", "Powered by libunftp"];
         // TODO: Add useful information here like operating server type and app name.
         Ok(Reply::new_multiline(ReplyCode::HelpMessage, text))

--- a/src/server/controlchan/commands/list.rs
+++ b/src/server/controlchan/commands/list.rs
@@ -13,11 +13,11 @@
 // to system, this information may be hard to use automatically
 // in a program, but may be quite useful to a human user.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::Command;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::prelude::*;
@@ -33,7 +33,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         let cmd: Command = args.cmd.clone();
         match session.data_cmd_tx.take() {

--- a/src/server/controlchan/commands/mdtm.rs
+++ b/src/server/controlchan/commands/mdtm.rs
@@ -1,8 +1,8 @@
 use crate::server::chancomms::InternalMsg;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage::{self, Metadata};
 use async_trait::async_trait;
 use chrono::offset::Utc;
@@ -33,7 +33,7 @@ where
     S::File: tokio::io::AsyncRead + Send + Sync,
     S::Metadata: 'static + storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let session = args.session.lock().await;
         let user = session.user.clone();
         let storage = Arc::clone(&session.storage);

--- a/src/server/controlchan/commands/mkd.rs
+++ b/src/server/controlchan/commands/mkd.rs
@@ -6,10 +6,10 @@
 // the pathname is relative).
 
 use crate::server::chancomms::InternalMsg;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::Reply;
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::channel::mpsc::Sender;
@@ -36,7 +36,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let session = args.session.lock().await;
         let user = session.user.clone();
         let storage = Arc::clone(&session.storage);

--- a/src/server/controlchan/commands/mode.rs
+++ b/src/server/controlchan/commands/mode.rs
@@ -12,10 +12,10 @@
 //
 // The default transfer mode is Stream.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -50,7 +50,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         match &self.params {
             ModeParam::Stream => Ok(Reply::new(ReplyCode::CommandOkay, "Using Stream transfer mode")),
             _ => Ok(Reply::new(

--- a/src/server/controlchan/commands/nlst.rs
+++ b/src/server/controlchan/commands/nlst.rs
@@ -14,10 +14,10 @@
 // the implementation of a "multiple get" function.
 
 use crate::server::controlchan::command::Command;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::prelude::*;
@@ -33,7 +33,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         let cmd: Command = args.cmd.clone();
         match session.data_cmd_tx.take() {

--- a/src/server/controlchan/commands/noop.rs
+++ b/src/server/controlchan/commands/noop.rs
@@ -4,10 +4,10 @@
 // entered commands. It specifies no action other than that the
 // server send an OK reply.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -21,7 +21,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         Ok(Reply::new(ReplyCode::CommandOkay, "Successfully did nothing"))
     }
 }

--- a/src/server/controlchan/commands/opts.rs
+++ b/src/server/controlchan/commands/opts.rs
@@ -7,10 +7,10 @@
 // definition of that command.  Where no OPTS behavior is defined for a
 // particular command there are no options available for that command.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -40,7 +40,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         match &self.option {
             Opt::UTF8 { on: true } => Ok(Reply::new(ReplyCode::FileActionOkay, "Always in UTF-8 mode.")),
             Opt::UTF8 { on: false } => Ok(Reply::new(ReplyCode::CommandNotImplementedForParameter, "Non UTF-8 mode not supported")),

--- a/src/server/controlchan/commands/pass.rs
+++ b/src/server/controlchan/commands/pass.rs
@@ -11,10 +11,10 @@
 // the sensitive password information.
 
 use crate::server::chancomms::InternalMsg;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::server::password;
 use crate::server::session::SessionState;
 use crate::storage;
@@ -43,7 +43,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         // let session_arc = args.session.clone();
         let session = args.session.lock().await;
         match &session.state {

--- a/src/server/controlchan/commands/pasv.rs
+++ b/src/server/controlchan/commands/pasv.rs
@@ -6,11 +6,11 @@
 // transfer command.  The response to this command includes the
 // host and port address this server is listening on.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::Command;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 
 use async_trait::async_trait;
@@ -62,7 +62,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         // obtain the ip address the client is connected to
         let conn_addr = match args.local_addr {
             std::net::SocketAddr::V4(addr) => addr,

--- a/src/server/controlchan/commands/pbsz.rs
+++ b/src/server/controlchan/commands/pbsz.rs
@@ -9,10 +9,10 @@
 //! of '0' to indicate that no buffering is taking place and the data connection should
 //! not be encapsulated.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -26,7 +26,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         Ok(Reply::new(ReplyCode::CommandOkay, "OK"))
     }
 }

--- a/src/server/controlchan/commands/port.rs
+++ b/src/server/controlchan/commands/port.rs
@@ -16,10 +16,10 @@
 // where h1 is the high order 8 bits of the internet host
 // address.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -33,7 +33,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         Ok(Reply::new(
             ReplyCode::CommandNotImplemented,
             "ACTIVE mode is not supported - use PASSIVE instead",

--- a/src/server/controlchan/commands/prot.rs
+++ b/src/server/controlchan/commands/prot.rs
@@ -1,9 +1,9 @@
 //! The RFC 2228 Data Channel Protection Level (`PROT`) command.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -38,7 +38,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: 'static + storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         match (args.tls_configured, self.param.clone()) {
             (true, ProtParam::Clear) => {
                 let mut session = args.session.lock().await;

--- a/src/server/controlchan/commands/pwd.rs
+++ b/src/server/controlchan/commands/pwd.rs
@@ -3,10 +3,10 @@
 // This command causes the name of the current working
 // directory to be returned in the reply.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -20,7 +20,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let session = args.session.lock().await;
         // TODO: properly escape double quotes in `cwd`
         Ok(Reply::new_with_string(

--- a/src/server/controlchan/commands/quit.rs
+++ b/src/server/controlchan/commands/quit.rs
@@ -13,10 +13,10 @@
 // logout (QUIT).
 
 use crate::server::chancomms::InternalMsg;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::channel::mpsc::Sender;
@@ -33,7 +33,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut tx: Sender<InternalMsg> = args.tx.clone();
         //TODO does this make sense? The command is not sent and yet an Ok is replied
         if let Err(send_res) = tx.send(InternalMsg::Quit).await {

--- a/src/server/controlchan/commands/rest.rs
+++ b/src/server/controlchan/commands/rest.rs
@@ -6,10 +6,10 @@
 //! See also: https://cr.yp.to/ftp/retr.html
 //!
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -31,7 +31,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: 'static + storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         if args.storage_features & storage::FEATURE_RESTART == 0 {
             return Ok(Reply::new(ReplyCode::CommandNotImplemented, "Not supported by the selected storage back-end."));
         }

--- a/src/server/controlchan/commands/retr.rs
+++ b/src/server/controlchan/commands/retr.rs
@@ -6,10 +6,10 @@
 // contents of the file at the server site shall be unaffected.
 
 use crate::server::controlchan::command::Command;
+use crate::server::controlchan::error::{ControlChanError, ControlChanErrorKind};
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::Reply;
-use crate::server::error::{FTPError, FTPErrorKind};
 use crate::storage;
 use async_trait::async_trait;
 use futures::prelude::*;
@@ -25,7 +25,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         let cmd: Command = args.cmd.clone();
         match session.data_cmd_tx.take() {
@@ -37,7 +37,7 @@ where
                 });
                 Ok(Reply::none())
             }
-            None => Err(FTPErrorKind::InternalServerError.into()),
+            None => Err(ControlChanErrorKind::InternalServerError.into()),
         }
     }
 }

--- a/src/server/controlchan/commands/rmd.rs
+++ b/src/server/controlchan/commands/rmd.rs
@@ -6,10 +6,10 @@
 // the pathname is relative).
 
 use crate::server::chancomms::InternalMsg;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::Reply;
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::prelude::*;
@@ -35,7 +35,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let session = args.session.lock().await;
         let storage: Arc<S> = Arc::clone(&session.storage);
         let path = session.cwd.join(self.path.clone());

--- a/src/server/controlchan/commands/rnfr.rs
+++ b/src/server/controlchan/commands/rnfr.rs
@@ -1,9 +1,9 @@
 //! The RFC 959 Rename From (`RNFR`) command
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use std::path::PathBuf;
@@ -26,7 +26,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         session.rename_from = Some(session.cwd.join(self.path.clone()));
         Ok(Reply::new(ReplyCode::FileActionPending, "Tell me, what would you like the new name to be?"))

--- a/src/server/controlchan/commands/rnto.rs
+++ b/src/server/controlchan/commands/rnto.rs
@@ -1,9 +1,9 @@
 //! The RFC 959 Rename To (`RNTO`) command
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use log::warn;
@@ -28,7 +28,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         let storage = Arc::clone(&session.storage);
         let reply = match session.rename_from.take() {

--- a/src/server/controlchan/commands/size.rs
+++ b/src/server/controlchan/commands/size.rs
@@ -1,8 +1,8 @@
 use crate::server::chancomms::InternalMsg;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage::{self, Metadata};
 use async_trait::async_trait;
 use futures::channel::mpsc::Sender;
@@ -29,7 +29,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: 'static + storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let session = args.session.lock().await;
         let user = session.user.clone();
         let start_pos: u64 = session.start_pos;

--- a/src/server/controlchan/commands/stat.rs
+++ b/src/server/controlchan/commands/stat.rs
@@ -18,10 +18,10 @@
 // the status of connections.
 
 use crate::server::chancomms::InternalMsg;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage::{self, Error, ErrorKind};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -49,7 +49,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: 'static + storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         match self.path.clone() {
             None => {
                 let text: Vec<&str> = vec!["Status:", "Powered by libunftp"];

--- a/src/server/controlchan/commands/stor.rs
+++ b/src/server/controlchan/commands/stor.rs
@@ -9,10 +9,10 @@
 // pathname does not already exist.
 
 use crate::server::controlchan::command::Command;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::prelude::*;
@@ -28,7 +28,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         let cmd: Command = args.cmd.clone();
         match session.data_cmd_tx.take() {

--- a/src/server/controlchan/commands/stou.rs
+++ b/src/server/controlchan/commands/stou.rs
@@ -1,10 +1,10 @@
 //! The RFC 959 Store File Uniquely (`STOU`) command
 
 use crate::server::controlchan::command::Command;
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 use futures::prelude::*;
@@ -23,7 +23,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         let uuid: String = Uuid::new_v4().to_string();
         let filename: &Path = std::path::Path::new(&uuid);

--- a/src/server/controlchan/commands/stru.rs
+++ b/src/server/controlchan/commands/stru.rs
@@ -12,10 +12,10 @@
 //
 // The default structure is File.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -53,7 +53,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         match &self.params {
             StruParam::File => Ok(Reply::new(ReplyCode::CommandOkay, "In File structure mode")),
             _ => Ok(Reply::new(

--- a/src/server/controlchan/commands/syst.rs
+++ b/src/server/controlchan/commands/syst.rs
@@ -9,10 +9,10 @@
 // the capabilities of the other peer. D.J. Bernstein recommends to just respond with
 // `UNIX Type: L8` for greatest compatibility.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -26,7 +26,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         Ok(Reply::new(ReplyCode::SystemType, "UNIX Type: L8"))
     }
 }

--- a/src/server/controlchan/commands/type_.rs
+++ b/src/server/controlchan/commands/type_.rs
@@ -26,10 +26,10 @@
 // argument is changed, Format then returns to the Non-print
 // default.
 
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::storage;
 use async_trait::async_trait;
 
@@ -43,7 +43,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, _args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         Ok(Reply::new(ReplyCode::CommandOkay, "Always in binary mode"))
     }
 }

--- a/src/server/controlchan/commands/user.rs
+++ b/src/server/controlchan/commands/user.rs
@@ -1,7 +1,7 @@
+use crate::server::controlchan::error::ControlChanError;
 use crate::server::controlchan::handler::CommandContext;
 use crate::server::controlchan::handler::CommandHandler;
 use crate::server::controlchan::{Reply, ReplyCode};
-use crate::server::error::FTPError;
 use crate::server::session::SessionState;
 use crate::storage;
 use async_trait::async_trait;
@@ -25,7 +25,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError> {
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         match session.state {
             SessionState::New | SessionState::WaitPass => {

--- a/src/server/controlchan/error.rs
+++ b/src/server/controlchan/error.rs
@@ -1,20 +1,20 @@
-//! Contains the `FTPError` struct that that defines the libunftp custom error type.
+//! Contains the `ControlChanError` struct that that defines the control channel error type.
 
-use super::controlchan::{ParseError, ParseErrorKind};
+use super::parse_error::{ParseError, ParseErrorKind};
 
 use failure::{Backtrace, Context, Fail};
 use std::fmt;
 
 /// The error type returned by this library.
 #[derive(Debug)]
-pub struct FTPError {
-    inner: Context<FTPErrorKind>,
+pub struct ControlChanError {
+    inner: Context<ControlChanErrorKind>,
 }
 
-/// A list specifying categories of FTP errors. It is meant to be used with the [FTPError] type.
+/// A list specifying categories of FTP errors. It is meant to be used with the [ControlChanError] type.
 #[derive(Eq, PartialEq, Debug, Fail)]
 #[allow(dead_code)]
-pub enum FTPErrorKind {
+pub enum ControlChanErrorKind {
     /// We encountered a system IO error.
     #[fail(display = "Failed to perform IO")]
     IOError,
@@ -50,20 +50,20 @@ pub enum FTPErrorKind {
     ControlChannelTimeout,
 }
 
-impl FTPError {
+impl ControlChanError {
     /// Creates a new FTP Error with the specific kind
-    pub fn new(kind: FTPErrorKind) -> Self {
-        FTPError { inner: Context::new(kind) }
+    pub fn new(kind: ControlChanErrorKind) -> Self {
+        ControlChanError { inner: Context::new(kind) }
     }
 
     /// Return the inner error kind of this error.
     #[allow(unused)]
-    pub fn kind(&self) -> &FTPErrorKind {
+    pub fn kind(&self) -> &ControlChanErrorKind {
         self.inner.get_context()
     }
 }
 
-impl Fail for FTPError {
+impl Fail for ControlChanError {
     fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
     }
@@ -73,47 +73,47 @@ impl Fail for FTPError {
     }
 }
 
-impl fmt::Display for FTPError {
+impl fmt::Display for ControlChanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.inner, f)
     }
 }
 
-impl From<FTPErrorKind> for FTPError {
-    fn from(kind: FTPErrorKind) -> FTPError {
-        FTPError { inner: Context::new(kind) }
+impl From<ControlChanErrorKind> for ControlChanError {
+    fn from(kind: ControlChanErrorKind) -> ControlChanError {
+        ControlChanError { inner: Context::new(kind) }
     }
 }
 
-impl From<Context<FTPErrorKind>> for FTPError {
-    fn from(inner: Context<FTPErrorKind>) -> FTPError {
-        FTPError { inner }
+impl From<Context<ControlChanErrorKind>> for ControlChanError {
+    fn from(inner: Context<ControlChanErrorKind>) -> ControlChanError {
+        ControlChanError { inner }
     }
 }
 
-impl From<std::io::Error> for FTPError {
-    fn from(err: std::io::Error) -> FTPError {
-        err.context(FTPErrorKind::IOError).into()
+impl From<std::io::Error> for ControlChanError {
+    fn from(err: std::io::Error) -> ControlChanError {
+        err.context(ControlChanErrorKind::IOError).into()
     }
 }
 
-impl From<std::str::Utf8Error> for FTPError {
-    fn from(err: std::str::Utf8Error) -> FTPError {
-        err.context(FTPErrorKind::UTF8Error).into()
+impl From<std::str::Utf8Error> for ControlChanError {
+    fn from(err: std::str::Utf8Error) -> ControlChanError {
+        err.context(ControlChanErrorKind::UTF8Error).into()
     }
 }
 
-impl From<ParseError> for FTPError {
-    fn from(err: ParseError) -> FTPError {
+impl From<ParseError> for ControlChanError {
+    fn from(err: ParseError) -> ControlChanError {
         match err.kind().clone() {
             ParseErrorKind::UnknownCommand { command } => {
                 // TODO: Do something smart with CoW to prevent copying the command around.
-                err.context(FTPErrorKind::UnknownCommand { command }).into()
+                err.context(ControlChanErrorKind::UnknownCommand { command }).into()
             }
-            ParseErrorKind::InvalidUTF8 => err.context(FTPErrorKind::UTF8Error).into(),
-            ParseErrorKind::InvalidCommand => err.context(FTPErrorKind::InvalidCommand).into(),
-            ParseErrorKind::InvalidToken { .. } => err.context(FTPErrorKind::UTF8Error).into(),
-            _ => err.context(FTPErrorKind::InvalidCommand).into(),
+            ParseErrorKind::InvalidUTF8 => err.context(ControlChanErrorKind::UTF8Error).into(),
+            ParseErrorKind::InvalidCommand => err.context(ControlChanErrorKind::InvalidCommand).into(),
+            ParseErrorKind::InvalidToken { .. } => err.context(ControlChanErrorKind::UTF8Error).into(),
+            _ => err.context(ControlChanErrorKind::InvalidCommand).into(),
         }
     }
 }

--- a/src/server/controlchan/handler.rs
+++ b/src/server/controlchan/handler.rs
@@ -1,7 +1,7 @@
+use super::error::ControlChanError;
 use crate::auth::Authenticator;
 use crate::server::controlchan::Command;
 use crate::server::controlchan::Reply;
-use crate::server::FTPError;
 use crate::server::InternalMsg;
 use crate::server::Session;
 use crate::storage;
@@ -20,7 +20,7 @@ where
     S::File: tokio::io::AsyncRead + Send,
     S::Metadata: storage::Metadata,
 {
-    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, FTPError>;
+    async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError>;
 }
 
 /// Convenience struct to group command args

--- a/src/server/controlchan/mod.rs
+++ b/src/server/controlchan/mod.rs
@@ -7,8 +7,7 @@ pub(crate) mod handler;
 
 pub(super) mod commands;
 
-pub(super) mod parse_error;
-pub use parse_error::{ParseError, ParseErrorKind};
+mod parse_error;
 
 pub(crate) mod event;
 pub(crate) use event::Event;
@@ -18,3 +17,7 @@ pub(crate) use codecs::FTPCodec;
 
 pub(crate) mod reply;
 pub(crate) use reply::{Reply, ReplyCode};
+
+mod error;
+pub(super) use error::ControlChanError;
+pub(crate) use error::ControlChanErrorKind;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,7 +3,6 @@
 mod chancomms;
 mod controlchan;
 mod datachan;
-pub(crate) mod error;
 pub(crate) mod ftpserver;
 mod io;
 mod password;
@@ -13,6 +12,6 @@ mod tls;
 pub(crate) use chancomms::InternalMsg;
 pub(crate) use controlchan::command::Command;
 pub(crate) use controlchan::reply::{Reply, ReplyCode};
+pub(crate) use controlchan::ControlChanErrorKind;
 pub(crate) use controlchan::Event;
-pub(crate) use error::{FTPError, FTPErrorKind};
 pub(self) use session::{Session, SessionState};


### PR DESCRIPTION
I'm trying to introduce a API public error type but the `FTPError` type was in the way. It looked like it was a suitable public type but it wasn't its merely a control channel error type for internal use to the lib so I renamed `server::FTPError` to `server::controlchan::ControlChanError` and `server::FTPErrorKind` to `server::controlchan::ControlChanErrorKind`