### PR TITLE
add examples to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ before_script:
 
 script:
   - cargo fmt --all -- --check
-  - cargo clippy --all-features -- -D warnings
-  - cargo test --verbose --all --all-features
-  - cargo build --verbose --all --all-features
+  - cargo clippy --all-features --all-targets -- -D warnings
+  - cargo test --verbose --all-features --all-targets
+  - cargo build --verbose --all-features --all-targets
 
 cache: cargo
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2018"
 async-trait = "0.1.30"
 regex = "1.3.6"
 futures = {version = "0.3.4", features = ["compat", "io-compat", "std"]}
-tokio = { version = "0.2.17", features = ["rt-core", "net", "sync", "io-util", "macros", "time", "fs"]}
+tokio = { version = "0.2.18", features = ["rt-core", "net", "sync", "io-util", "macros", "time", "fs"]}
 tokio-util = { version = "0.3.1", features=["codec"] }
 tokio-tls = { version = "0.3.0" }
 native-tls = "0.2.4"
@@ -37,7 +37,6 @@ failure_derive = "0.1.7"
 pam-auth = { package = "pam", version = "0.7.0", optional = true }
 hyper = { version = "0.13.4", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
-http = { version = "0.2.1", optional = true }
 serde = { version = "1.0.106", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.51", optional = true }
 path_abs = "0.5.0"
@@ -55,12 +54,12 @@ tempfile = "3.1.0"
 ftp = "3.0.1"
 pretty_env_logger = "0.4.0"
 pretty_assertions = "0.6.1"
-tokio = { version = "0.2.17", features = ["rt-threaded"]}
+tokio = { version = "0.2.18", features = ["rt-threaded"]}
 clap = "2.33.0"
 
 [features]
 pam_auth = ["pam-auth"]
-rest_auth = ["hyper", "percent-encoding", "http", "serde", "serde_json"]
+rest_auth = ["hyper", "percent-encoding", "serde", "serde_json"]
 jsonfile_auth = ["serde", "serde_json"]
 cloud_storage = ["oauth2", "mime", "percent-encoding", "hyper", "serde", "serde_json"]
 oauth2 = ["yup-oauth2", "hyper-rustls"]

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ build: # Create a release build
 .PHONY: pr-prep
 pr-prep: examples # Runs checks to ensure you're ready for a pull request
 	cargo fmt --all -- --check
-	cargo clippy --all-features -- -D warnings
-	cargo test --all --all-features
-	cargo build --all --all-features
+	cargo clippy --all-features --all-targets -- -D warnings
+	cargo test --all-features --all-targets
+	cargo build --all-features --all-targets
 	cargo doc --all-features --no-deps
 
 .PHONY: publish

--- a/examples/gcs.rs
+++ b/examples/gcs.rs
@@ -31,10 +31,10 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
     let service_account_key = matches
         .value_of(SERVICE_ACCOUNT_KEY)
-        .ok_or_else(|| "Internal error: use of an undefined command line parameter")?;
+        .ok_or("Internal error: use of an undefined command line parameter")?;
     let bucket_name = matches
         .value_of(BUCKET_NAME)
-        .ok_or_else(|| "Internal error: use of an undefined command line parameter")?
+        .ok_or("Internal error: use of an undefined command line parameter")?
         .to_owned();
 
     let service_account_key = yup_oauth2::read_service_account_key(service_account_key).await?;

--- a/src/auth/rest.rs
+++ b/src/auth/rest.rs
@@ -6,8 +6,7 @@ use crate::auth::anonymous::*;
 use crate::auth::*;
 
 use async_trait::async_trait;
-use http::uri::InvalidUri;
-use hyper::{Body, Client, Method, Request};
+use hyper::{http::uri::InvalidUri, Body, Client, Method, Request};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use regex::Regex;
 use serde_json::{json, Value};

--- a/src/storage/cloud_storage/mod.rs
+++ b/src/storage/cloud_storage/mod.rs
@@ -8,11 +8,11 @@ use async_trait::async_trait;
 use bytes::{buf::BufExt, Buf};
 use chrono::{DateTime, Utc};
 use futures::prelude::*;
-use hyper::http::{StatusCode, Uri};
 use hyper::{
     body::aggregate,
     client::connect::{dns::GaiResolver, HttpConnector},
     http::{header, Method},
+    http::{StatusCode, Uri},
     Body, Client, Request, Response,
 };
 use hyper_rustls::HttpsConnector;


### PR DESCRIPTION
add examples to CI
remove deprecated '--all' flags, since this is not a workspace
remove `http` from the dependencies
small improvement in the gcs example