### PR TITLE
No IP needed to start proxy protocol mode

### DIFF
--- a/examples/proxyprotocol.rs
+++ b/examples/proxyprotocol.rs
@@ -5,9 +5,7 @@ pub async fn main() {
     pretty_env_logger::init();
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::new_with_fs_root(std::env::temp_dir())
-        .proxy_protocol_mode("10.0.0.1", 2121)
-        .unwrap();
+    let server = libunftp::Server::new_with_fs_root(std::env::temp_dir()).proxy_protocol_mode(2121);
 
     info!("Starting ftp server with proxy protocol on {}", addr);
     server.listen(addr).await;

--- a/src/server/proxy_protocol.rs
+++ b/src/server/proxy_protocol.rs
@@ -19,6 +19,18 @@ lazy_static! {
     static ref OS_RNG: Mutex<OsRng> = Mutex::new(OsRng);
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum ProxyMode {
+    Off,
+    On { external_control_port: u16 },
+}
+
+impl From<u16> for ProxyMode {
+    fn from(port: u16) -> Self {
+        ProxyMode::On { external_control_port: port }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum ProxyError {
     CrlfError,


### PR DESCRIPTION
The external IP address of the proxy is not actually needed when initialising proxy protocol mode. Only the port is needed.