### PR TITLE
Handle list() errors more gracefully

### DIFF
--- a/src/server/chancomms.rs
+++ b/src/server/chancomms.rs
@@ -46,6 +46,8 @@ pub enum InternalMsg {
     UnknownRetrieveError,
     /// Listed the directory successfully
     DirectorySuccessfullyListed,
+    /// Failed to list the directory contents
+    DirectoryListFailure,
     /// Successfully cwd
     CwdSuccess,
     /// File successfully deleted

--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -398,6 +398,7 @@ where
         DataConnectionClosedAfterStor => Ok(Reply::new(ReplyCode::FileActionOkay, "unFTP holds your data for you")),
         UnknownRetrieveError => Ok(Reply::new(ReplyCode::TransientFileError, "Unknown Error")),
         DirectorySuccessfullyListed => Ok(Reply::new(ReplyCode::ClosingDataConnection, "Listed the directory")),
+        DirectoryListFailure => Ok(Reply::new(ReplyCode::ClosingDataConnection, "Failed to list the directory")),
         CwdSuccess => Ok(Reply::new(ReplyCode::FileActionOkay, "Successfully cwd")),
         DelSuccess => Ok(Reply::new(ReplyCode::FileActionOkay, "File successfully removed")),
         DelFail => Ok(Reply::new(ReplyCode::TransientFileError, "Failed to delete the file")),

--- a/src/storage/storage_backend.rs
+++ b/src/storage/storage_backend.rs
@@ -134,12 +134,12 @@ pub trait StorageBackend<U: Sync + Send> {
         <Self as StorageBackend<U>>::Metadata: Metadata;
 
     /// Returns some bytes that make up a directory listing that can immediately be sent to the client.
-    async fn list_fmt<P>(&self, user: &Option<U>, path: P) -> std::result::Result<std::io::Cursor<Vec<u8>>, std::io::Error>
+    async fn list_fmt<P>(&self, user: &Option<U>, path: P) -> std::result::Result<std::io::Cursor<Vec<u8>>, Error>
     where
         P: AsRef<Path> + Send,
         Self::Metadata: Metadata + 'static,
     {
-        let list = self.list(user, path).await.map_err(|_| std::io::Error::from(std::io::ErrorKind::Other))?;
+        let list = self.list(user, path).await?;
 
         let file_infos: Vec<u8> = list.iter().map(|fi| format!("{}\r\n", fi).into_bytes()).concat();
 


### PR DESCRIPTION
Currently, running both with my own storage backend as well as with `new_with_fs_root()`, when an error occurs in `list()`, the server doesn't send a reply at all - from the FTP client's standpoint, it just hangs.  Running with logging turned up it does print something to the log, which is a plus, but hanging the FTP session with something as simple as `ls /path/that/does/not/exist` doesn't seem ideal :)

With the changes in this PR, I bubble up any errors that occurred in `list()` for logging purposes, and send a reply to the client indicating failure.  Additionally, the rest of the steps occur the same as they do on success - closing the data socket, then notifying the main thread (although the internal message differs) that we're finished.

Related to #163 in spirit, but probably not in letter...suggestions welcome.  If this looks good it may make sense to apply the same treatment to other storage backend wrappers.