### PR TITLE
Structured logging (use slog over log) + logging of trace id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ tokio-rustls = { version = "0.13.0" }
 rustls = "0.17.0"
 bytes = "0.5.4"
 lazy_static = "1.4.0"
-log = "0.4.8"
+slog = { version = "2.4.1", features = ["max_level_trace", "release_max_level_warn"] }
+slog-stdlog = "4.0.0"
 chrono = {version = "0.4.11", features = ["serde"]}
 failure = "0.1.7"
 failure_derive = "0.1.7"
@@ -62,6 +63,7 @@ pretty_assertions = "0.6.1"
 tokio = { version = "0.2.20", features = ["rt-threaded"]}
 clap = "2.33.0"
 tracing-subscriber = "0.2.5"
+log = "0.4.8"
 
 [features]
 pam_auth = ["pam-auth"]

--- a/src/auth/jsonfile.rs
+++ b/src/auth/jsonfile.rs
@@ -4,7 +4,6 @@
 
 use crate::auth::*;
 use async_trait::async_trait;
-use log::{info, warn};
 use serde::Deserialize;
 use std::{fs, time::Duration};
 use tokio::time::delay_for;
@@ -56,18 +55,14 @@ impl Authenticator<DefaultUser> for JsonFileAuthenticator {
         for c in credentials_list.iter() {
             if username == c.username {
                 if password == c.password {
-                    info!("Successful login by user {}", username);
                     return Ok(DefaultUser {});
                 } else {
-                    warn!("Failed login for user {}: bad password", username);
                     // punish the failed login with a 1500ms delay before returning the error
                     delay_for(Duration::from_millis(1500)).await;
                     return Err(Box::new(BadPasswordError));
                 }
             }
         }
-        warn!("Failed login for user \"{}\": unknown user", username);
-
         // punish the failed login with a 1500ms delay before returning the error
         delay_for(Duration::from_millis(1500)).await;
         Err(Box::new(UnknownUsernameError))

--- a/src/auth/rest.rs
+++ b/src/auth/rest.rs
@@ -128,7 +128,7 @@ impl Authenticator<DefaultUser> for RestAuthenticator {
         let selector = self.selector.clone();
         let regex = self.regex.clone();
 
-        debug!("{} {}", url, body);
+        //slog::debug!("{} {}", url, body);
 
         let req = Request::builder()
             .method(method)
@@ -165,7 +165,7 @@ fn encode_string_json(string: &str) -> String {
             '"' => res.push_str("\\\""),
             ' '..='~' => res.push(i),
             _ => {
-                error!("special character {} is not supported", i);
+                //slog::error!("special character {} is not supported", i);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,3 @@ pub(crate) mod server;
 pub mod storage;
 
 pub use crate::server::ftpserver::Server;
-
-#[cfg(feature = "rest_auth")]
-#[macro_use]
-extern crate log;

--- a/src/server/controlchan/commands/ccc.rs
+++ b/src/server/controlchan/commands/ccc.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::{channel::mpsc::Sender, prelude::*};
-use log::warn;
 
 #[derive(Debug)]
 pub struct Ccc;
@@ -31,10 +30,11 @@ where
     async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut tx: Sender<InternalMsg> = args.tx.clone();
         let session = args.session.lock().await;
+        let logger = args.logger;
         if session.cmd_tls {
             tokio::spawn(async move {
                 if let Err(err) = tx.send(InternalMsg::PlaintextControlChannel).await {
-                    warn!("{}", err);
+                    slog::warn!(logger, "{}", err);
                 }
             });
             Ok(Reply::new(ReplyCode::CommandOkay, "control channel in plaintext now"))

--- a/src/server/controlchan/commands/dele.rs
+++ b/src/server/controlchan/commands/dele.rs
@@ -19,7 +19,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::{channel::mpsc::Sender, prelude::*};
-use log::warn;
 use std::{string::String, sync::Arc};
 
 #[derive(Debug)]
@@ -49,16 +48,17 @@ where
         let path = session.cwd.join(self.path.clone());
         let mut tx_success: Sender<InternalMsg> = args.tx.clone();
         let mut tx_fail: Sender<InternalMsg> = args.tx.clone();
+        let logger = args.logger;
         tokio::spawn(async move {
             match storage.del(&user, path).await {
                 Ok(_) => {
                     if let Err(err) = tx_success.send(InternalMsg::DelSuccess).await {
-                        warn!("{}", err);
+                        slog::warn!(logger, "{}", err);
                     }
                 }
                 Err(err) => {
                     if let Err(err) = tx_fail.send(InternalMsg::StorageError(err)).await {
-                        warn!("{}", err);
+                        slog::warn!(logger, "{}", err);
                     }
                 }
             }

--- a/src/server/controlchan/commands/list.rs
+++ b/src/server/controlchan/commands/list.rs
@@ -24,7 +24,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::prelude::*;
-use log::warn;
 
 #[derive(Debug)]
 pub struct List;
@@ -41,11 +40,12 @@ where
     async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         let cmd: Command = args.cmd.clone();
+        let logger = args.logger;
         match session.data_cmd_tx.take() {
             Some(mut tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(cmd).await {
-                        warn!("could not notify data channel to respond with LIST. {}", err);
+                        slog::warn!(logger, "could not notify data channel to respond with LIST. {}", err);
                     }
                 });
                 Ok(Reply::new(ReplyCode::FileStatusOkay, "Sending directory list"))

--- a/src/server/controlchan/commands/nlst.rs
+++ b/src/server/controlchan/commands/nlst.rs
@@ -25,7 +25,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::prelude::*;
-use log::warn;
 
 #[derive(Debug)]
 pub struct Nlst;
@@ -42,11 +41,12 @@ where
     async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         let cmd: Command = args.cmd.clone();
+        let logger = args.logger;
         match session.data_cmd_tx.take() {
             Some(mut tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(cmd).await {
-                        warn!("{}", err);
+                        slog::warn!(logger, "{}", err);
                     }
                 });
                 Ok(Reply::new(ReplyCode::FileStatusOkay, "Sending directory list"))

--- a/src/server/controlchan/commands/quit.rs
+++ b/src/server/controlchan/commands/quit.rs
@@ -26,7 +26,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::{channel::mpsc::Sender, prelude::*};
-use log::warn;
 
 #[derive(Debug)]
 pub struct Quit;
@@ -42,9 +41,10 @@ where
     #[tracing_attributes::instrument]
     async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut tx: Sender<InternalMsg> = args.tx.clone();
+        let logger = args.logger;
         //TODO does this make sense? The command is not sent and yet an Ok is replied
         if let Err(send_res) = tx.send(InternalMsg::Quit).await {
-            warn!("could not send internal message: QUIT. {}", send_res);
+            slog::warn!(logger, "could not send internal message: QUIT. {}", send_res);
         }
         Ok(Reply::new(ReplyCode::ClosingControlConnection, "Bye!"))
     }

--- a/src/server/controlchan/commands/retr.rs
+++ b/src/server/controlchan/commands/retr.rs
@@ -20,7 +20,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::prelude::*;
-use log::warn;
 
 #[derive(Debug)]
 pub struct Retr;
@@ -37,11 +36,12 @@ where
     async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         let cmd: Command = args.cmd.clone();
+        let logger = args.logger;
         match session.data_cmd_tx.take() {
             Some(mut tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(cmd).await {
-                        warn!("{}", err);
+                        slog::warn!(logger, "{}", err);
                     }
                 });
                 Ok(Reply::new(ReplyCode::FileStatusOkay, "Sending data"))

--- a/src/server/controlchan/commands/size.rs
+++ b/src/server/controlchan/commands/size.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::{channel::mpsc::Sender, prelude::*};
-use log::warn;
 use std::{path::PathBuf, sync::Arc};
 
 #[derive(Debug)]
@@ -43,6 +42,7 @@ where
         let path = session.cwd.join(self.path.clone());
         let mut tx_success: Sender<InternalMsg> = args.tx.clone();
         let mut tx_fail: Sender<InternalMsg> = args.tx.clone();
+        let logger = args.logger;
 
         tokio::spawn(async move {
             match storage.metadata(&user, &path).await {
@@ -54,12 +54,12 @@ where
                         ))
                         .await
                     {
-                        warn!("{}", err);
+                        slog::warn!(logger, "{}", err);
                     }
                 }
                 Err(err) => {
                     if let Err(err) = tx_fail.send(InternalMsg::StorageError(err)).await {
-                        warn!("{}", err);
+                        slog::warn!(logger, "{}", err);
                     }
                 }
             }

--- a/src/server/controlchan/commands/stor.rs
+++ b/src/server/controlchan/commands/stor.rs
@@ -20,7 +20,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::prelude::*;
-use log::warn;
 
 #[derive(Debug)]
 pub struct Stor;
@@ -37,11 +36,12 @@ where
     async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
         let cmd: Command = args.cmd.clone();
+        let logger = args.logger;
         match session.data_cmd_tx.take() {
             Some(mut tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(cmd).await {
-                        warn!("{}", err);
+                        slog::warn!(logger, "{}", err);
                     }
                 });
                 Ok(Reply::new(ReplyCode::FileStatusOkay, "Ready to receive data"))

--- a/src/server/controlchan/commands/stou.rs
+++ b/src/server/controlchan/commands/stou.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::prelude::*;
-use log::warn;
 use std::path::Path;
 use uuid::Uuid;
 
@@ -34,11 +33,12 @@ where
         let uuid: String = Uuid::new_v4().to_string();
         let filename: &Path = std::path::Path::new(&uuid);
         let path: String = session.cwd.join(&filename).to_string_lossy().to_string();
+        let logger = args.logger;
         match session.data_cmd_tx.take() {
             Some(mut tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(Command::Stor { path }).await {
-                        warn!("sending command failed. {}", err);
+                        slog::warn!(logger, "sending command failed. {}", err);
                     }
                 });
                 Ok(Reply::new_with_string(ReplyCode::FileStatusOkay, filename.to_string_lossy().to_string()))

--- a/src/server/controlchan/handler.rs
+++ b/src/server/controlchan/handler.rs
@@ -44,4 +44,5 @@ where
     pub storage_features: u32,
     pub proxyloop_msg_tx: Option<ProxyLoopSender<S, U>>,
     pub control_connection_info: Option<ConnectionTuple>,
+    pub logger: slog::Logger,
 }

--- a/src/storage/filesystem.rs
+++ b/src/storage/filesystem.rs
@@ -3,7 +3,6 @@
 use crate::storage::{Error, ErrorKind, Fileinfo, Metadata, Result, StorageBackend};
 use async_trait::async_trait;
 use futures::prelude::*;
-use log::warn;
 use std::{
     fmt::Debug,
     path::{Path, PathBuf},
@@ -212,8 +211,8 @@ impl<U: Send + Sync + Debug> StorageBackend<U> for Filesystem {
                     let r = tokio::fs::rename(from_rename, to).await;
                     match r {
                         Ok(_) => Ok(()),
-                        Err(e) => {
-                            warn!("could not rename file: {:?}", e);
+                        Err(_e) => {
+                            // TODO: Propagate actual error.
                             Err(Error::from(ErrorKind::PermanentFileNotAvailable))
                         }
                     }
@@ -221,8 +220,8 @@ impl<U: Send + Sync + Debug> StorageBackend<U> for Filesystem {
                     Err(Error::from(ErrorKind::PermanentFileNotAvailable))
                 }
             }
-            Err(e) => {
-                warn!("could not get file metadata: {:?}", e);
+            Err(_e) => {
+                // TODO: Propagate actual error.
                 Err(Error::from(ErrorKind::PermanentFileNotAvailable))
             }
         }

--- a/src/storage/storage_backend.rs
+++ b/src/storage/storage_backend.rs
@@ -4,7 +4,6 @@ use super::error::Error;
 use async_trait::async_trait;
 use chrono::prelude::{DateTime, Utc};
 use itertools::Itertools;
-use log::warn;
 use std::{
     fmt::{self, Debug, Formatter},
     path::Path,
@@ -79,7 +78,6 @@ where
         let path = match basename {
             Some(v) => v.as_os_str().to_string_lossy(),
             None => {
-                warn!("error parsing path components");
                 return Err(std::fmt::Error);
             }
         };


### PR DESCRIPTION
This PR replaces use of the [log](https://crates.io/crates/log) crate with structured logger [slog](https://crates.io/crates/slog) and then sets up a logger hierarchy so that a session-unique _trace id_ is logged everywhere.

Also, lib users can now pass in they're own logger to use using this method defined for the Server struct:

```rust
    /// Sets the slog structured logger to use
    pub fn logger<L: Into<Option<slog::Logger>>>(mut self, logger: L) -> Self {
        self.logger = logger.into().unwrap_or_else(|| slog::Logger::root(slog_stdlog::StdLog {}.fuse(), slog::o!()));
        self
    }
```

e.g.: 

```rust
    let server = Server::new_with_authenticator(storage_backend, auther)
        .greeting("Welcome to my ftp server")
        .passive_ports(start_port..end_port)
        .idle_session_timeout(idle_timeout)
        .logger(root_log.new(o!("in" => "libunftp")))

```

Closes #226

Sample logging:

![image](https://user-images.githubusercontent.com/2511554/85858510-0d1d9a80-b7bc-11ea-8432-b860a521ab12.png)
