### PR TITLE
enable tracing by changing return type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ failure_derive = "0.1.8"
 hyper = { version = "0.13.7", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 serde = { version = "1.0.114", optional = true, features = ["derive"] }
-serde_json = { version = "1.0.56", optional = true }
+serde_json = { version = "1.0.57", optional = true }
 path_abs = "0.5.0"
 prometheus = "0.9.0"
 uuid = { version = "0.8.1", features = ["v4"] }

--- a/src/auth/anonymous.rs
+++ b/src/auth/anonymous.rs
@@ -25,7 +25,7 @@ pub struct AnonymousAuthenticator;
 impl Authenticator<DefaultUser> for AnonymousAuthenticator {
     #[allow(clippy::type_complexity)]
     #[tracing_attributes::instrument]
-    async fn authenticate(&self, _username: &str, _password: &str) -> Result<DefaultUser, Box<dyn std::error::Error + Send + Sync>> {
+    async fn authenticate(&self, _username: &str, _password: &str) -> Result<DefaultUser, AuthenticationError> {
         Ok(DefaultUser {})
     }
 }

--- a/src/auth/authenticator.rs
+++ b/src/auth/authenticator.rs
@@ -14,27 +14,23 @@ where
     U: UserDetail,
 {
     /// Authenticate the given user with the given password.
-    async fn authenticate(&self, username: &str, password: &str) -> Result<U, Box<dyn std::error::Error + Send + Sync>>;
+    async fn authenticate(&self, username: &str, password: &str) -> Result<U, AuthenticationError>;
 }
 
+/// The error type for authentication errors
 #[derive(Debug)]
-pub(crate) struct BadPasswordError;
+pub struct AuthenticationError;
 
-impl fmt::Display for BadPasswordError {
+impl fmt::Display for AuthenticationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "bad password")
+        write!(f, "Authentication error")
     }
 }
 
-impl Error for BadPasswordError {}
+impl Error for AuthenticationError {}
 
-#[derive(Debug)]
-pub(crate) struct UnknownUsernameError;
-
-impl fmt::Display for UnknownUsernameError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "unknown user")
+impl std::convert::From<std::io::Error> for AuthenticationError {
+    fn from(_: std::io::Error) -> Self {
+        AuthenticationError
     }
 }
-
-impl Error for UnknownUsernameError {}

--- a/src/auth/jsonfile.rs
+++ b/src/auth/jsonfile.rs
@@ -46,8 +46,8 @@ impl JsonFileAuthenticator {
 #[async_trait]
 impl Authenticator<DefaultUser> for JsonFileAuthenticator {
     #[allow(clippy::type_complexity)]
-    // FIXME: fails compile for unknown reasons   #[tracing_attributes::instrument]
-    async fn authenticate(&self, _username: &str, _password: &str) -> Result<DefaultUser, Box<dyn std::error::Error + Send + Sync>> {
+    #[tracing_attributes::instrument]
+    async fn authenticate(&self, _username: &str, _password: &str) -> Result<DefaultUser, AuthenticationError> {
         let username = _username.to_string();
         let password = _password.to_string();
         let credentials_list = self.credentials_list.clone();
@@ -59,12 +59,12 @@ impl Authenticator<DefaultUser> for JsonFileAuthenticator {
                 } else {
                     // punish the failed login with a 1500ms delay before returning the error
                     delay_for(Duration::from_millis(1500)).await;
-                    return Err(Box::new(BadPasswordError));
+                    return Err(AuthenticationError {});
                 }
             }
         }
         // punish the failed login with a 1500ms delay before returning the error
         delay_for(Duration::from_millis(1500)).await;
-        Err(Box::new(UnknownUsernameError))
+        Err(AuthenticationError {})
     }
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -19,7 +19,7 @@
 //! 2. Implement the [`Authenticator`] trait and optionally the [`UserDetail`] trait:
 //!
 //! ```no_run
-//! use libunftp::auth::{Authenticator, UserDetail};
+//! use libunftp::auth::{Authenticator, AuthenticationError, UserDetail};
 //! use async_trait::async_trait;
 //!
 //! #[derive(Debug)]
@@ -27,7 +27,7 @@
 //!
 //! #[async_trait]
 //! impl Authenticator<RandomUser> for RandomAuthenticator {
-//!     async fn authenticate(&self, _username: &str, _password: &str) -> Result<RandomUser, Box<dyn std::error::Error + Send + Sync>> {
+//!     async fn authenticate(&self, _username: &str, _password: &str) -> Result<RandomUser, AuthenticationError> {
 //!         Ok(RandomUser{})
 //!     }
 //! }
@@ -63,9 +63,9 @@ pub mod anonymous;
 pub use anonymous::AnonymousAuthenticator;
 
 pub(crate) mod authenticator;
-pub use authenticator::Authenticator;
 #[allow(unused_imports)]
-pub(crate) use authenticator::{BadPasswordError, UnknownUsernameError};
+pub use authenticator::AuthenticationError;
+pub use authenticator::Authenticator;
 
 mod user;
 pub use user::{DefaultUser, UserDetail};

--- a/src/auth/pam.rs
+++ b/src/auth/pam.rs
@@ -27,7 +27,7 @@ impl PAMAuthenticator {
 impl Authenticator<DefaultUser> for PAMAuthenticator {
     #[allow(clippy::type_complexity)]
     #[tracing_attributes::instrument]
-    async fn authenticate(&self, username: &str, password: &str) -> Result<DefaultUser, Box<dyn std::error::Error + Send + Sync>> {
+    async fn authenticate(&self, username: &str, password: &str) -> Result<DefaultUser, AuthenticationError> {
         let service = self.service.clone();
         let username = username.to_string();
         let password = password.to_string();
@@ -37,5 +37,11 @@ impl Authenticator<DefaultUser> for PAMAuthenticator {
         auth.get_handler().set_credentials(&username, &password);
         auth.authenticate()?;
         Ok(DefaultUser {})
+    }
+}
+
+impl std::convert::From<pam_auth::PamError> for AuthenticationError {
+    fn from(_: pam_auth::PamError) -> Self {
+        AuthenticationError
     }
 }


### PR DESCRIPTION
In addition to make tracing available, this change hides the difference between a username error and a bad password error.

This change is also breaking the API.