### PR TITLE
2x speed on GET for filesystem back-end

### DIFF
--- a/src/storage/filesystem.rs
+++ b/src/storage/filesystem.rs
@@ -65,7 +65,7 @@ impl Filesystem {
 
 #[async_trait]
 impl<U: Send + Sync + Debug> StorageBackend<U> for Filesystem {
-    type File = tokio::fs::File;
+    type File = tokio::io::BufReader<tokio::fs::File>;
     type Metadata = std::fs::Metadata;
 
     fn supported_features(&self) -> u32 {
@@ -117,7 +117,7 @@ impl<U: Send + Sync + Debug> StorageBackend<U> for Filesystem {
             if start_pos > 0 {
                 file.seek(std::io::SeekFrom::Start(start_pos)).await?;
             }
-            Ok(file)
+            Ok(tokio::io::BufReader::new(file))
         }
         .map_err(|error: std::io::Error| match error.kind() {
             std::io::ErrorKind::NotFound => Error::from(ErrorKind::PermanentFileNotAvailable),


### PR DESCRIPTION
This MR improves the speed of the GET operation when using the filesystem back-end. 

Tested with unFTP on a 177MB file.

**Before:**

![image](https://user-images.githubusercontent.com/2511554/90884974-0755c700-e3b1-11ea-9df9-cf5b6380d8d9.png)

**After:**

![image](https://user-images.githubusercontent.com/2511554/90884857-d4abce80-e3b0-11ea-9470-ff3d450882a6.png)
