### PR TITLE
Fixed cloud storage backend list issues (#228)

### DIFF
--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -117,7 +117,13 @@ where
     #[tracing_attributes::instrument]
     async fn exec_list(self, path: Option<String>) {
         let path = match path {
-            Some(path) => self.cwd.join(path),
+            Some(path) => {
+                if path == "." {
+                    self.cwd.clone()
+                } else {
+                    self.cwd.join(path)
+                }
+            }
             None => self.cwd.clone(),
         };
         let mut tx_ok = self.control_msg_tx.clone();

--- a/src/storage/cloud_storage/mod.rs
+++ b/src/storage/cloud_storage/mod.rs
@@ -105,7 +105,7 @@ impl<U: Sync + Send + Debug> StorageBackend<U> for CloudStorage {
     where
         <Self as StorageBackend<U>>::Metadata: Metadata,
     {
-        let uri: Uri = self.uris.list(&path)?;
+        let uri: Uri = self.uris.list(path)?;
 
         let client: Client<HttpsConnector<HttpConnector<GaiResolver>>, Body> = self.client.clone();
 

--- a/src/storage/cloud_storage/response_body.rs
+++ b/src/storage/cloud_storage/response_body.rs
@@ -20,10 +20,18 @@ pub(crate) struct Item {
 impl ResponseBody {
     pub(crate) fn list(self) -> Result<Vec<Fileinfo<PathBuf, ObjectMetadata>>, Error> {
         let files: Vec<Fileinfo<PathBuf, ObjectMetadata>> = self.items.map_or(Ok(vec![]), move |items: Vec<Item>| {
-            items.iter().map(move |item: &Item| item.to_file_info()).collect()
+            items
+                .iter()
+                .filter(|item: &&Item| !item.name.ends_with('/'))
+                .map(move |item: &Item| item.to_file_info())
+                .collect()
         })?;
         let dirs: Vec<Fileinfo<PathBuf, ObjectMetadata>> = self.prefixes.map_or(Ok(vec![]), |prefixes: Vec<String>| {
-            prefixes.iter().map(|prefix| prefix_to_file_info(prefix)).collect()
+            prefixes
+                .iter()
+                .filter(|prefix| *prefix != "//")
+                .map(|prefix| prefix_to_file_info(prefix))
+                .collect()
         })?;
         let result: &mut Vec<Fileinfo<PathBuf, ObjectMetadata>> = &mut vec![];
         result.extend(dirs);

--- a/src/storage/cloud_storage/uri.rs
+++ b/src/storage/cloud_storage/uri.rs
@@ -18,12 +18,17 @@ impl GcsUri {
         make_uri(format!("{}/storage/v1/b/{}/o/{}", self.base_url, self.bucket, path_str(path)?))
     }
 
-    pub fn list<P: AsRef<Path>>(&self, path: &P) -> Result<Uri, Error> {
+    pub fn list<P: AsRef<Path>>(&self, path: P) -> Result<Uri, Error> {
+        let mut prefix = format!("{}", path.as_ref().display());
+        if !prefix.ends_with('/') {
+            prefix.push('/');
+        }
         make_uri(format!(
-            "{}/storage/v1/b/{}/o?delimiter=/&prefix={}",
+            "{}/storage/v1/b/{}/o?prettyPrint=false&fields={}&delimiter=/&prefix={}",
             self.base_url,
             self.bucket,
-            path_str(path)?
+            "kind,prefixes,items(id,name,size,updated)", // limit the fields
+            path_str(prefix.as_str())?
         ))
     }
 


### PR DESCRIPTION
This MR fixes 3 issues regarding LIST for the GCS storage back-end:

- #228 - Empty directory contains itself
- `ls` without arguments didn't actually work except in the root directory.
- `ls .`  didn't yield the content of the current directory.

Slight optimization to the list call to GCS in that we only ask to return JSON properties we actually need.