### PR TITLE
Fixed display issues when no directory dates are available - current …

### DIFF
--- a/src/storage/storage_backend.rs
+++ b/src/storage/storage_backend.rs
@@ -103,7 +103,7 @@ where
             .metadata
             .modified()
             .map(|x| DateTime::<Utc>::from(x).format("%b %d %H:%M").to_string())
-            .unwrap_or_else(|_| "-".to_string());
+            .unwrap_or_else(|_| "--- -- --:--".to_string());
         let basename = self.path.as_ref().components().last();
         let path = match basename {
             Some(v) => v.as_os_str().to_string_lossy(),


### PR DESCRIPTION
This MR changes the LIST output when no dates are available from:

![image](https://user-images.githubusercontent.com/2511554/91669142-11936600-eb13-11ea-9b44-70b707e98c4d.png)

to

![image](https://user-images.githubusercontent.com/2511554/91669148-1526ed00-eb13-11ea-91b5-fa7474033847.png)

which prevents this issue in FileZilla:

![image](https://user-images.githubusercontent.com/2511554/91669159-2d970780-eb13-11ea-9e9c-725fd753d99a.png)

(the ` - ` prefix in the directory names should not be there.