### PR TITLE
Added a configuration option to enforce FTPS on the control channel

### DIFF
--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -11,7 +11,7 @@ use crate::{
             handler::{CommandContext, CommandHandler},
             Reply, ReplyCode,
         },
-        ftpserver::options::PassiveHost,
+        ftpserver::options::{FtpsRequired, PassiveHost},
         proxy_protocol::ConnectionTuple,
         session::SharedSession,
         tls::FTPSConfig,
@@ -51,6 +51,7 @@ where
     pub collect_metrics: bool,
     pub idle_session_timeout: Duration,
     pub logger: slog::Logger,
+    pub ftps_required: FtpsRequired,
 }
 
 /// Does TCP processing when a FTP client connects
@@ -72,6 +73,7 @@ where
         passive_ports,
         passive_host,
         ftps_config,
+        ftps_required,
         collect_metrics,
         idle_session_timeout,
         logger,
@@ -105,7 +107,8 @@ where
         proxyloop_msg_tx,
         control_connection_info,
     );
-    let event_handler_chain = handle_with_auth::<S, U, _>(shared_session, event_handler_chain);
+    let event_handler_chain = handle_with_auth::<S, U, _>(shared_session.clone(), event_handler_chain);
+    let event_handler_chain = handle_checking_ftps_requirement::<S, U, _>(event_handler_chain, shared_session, ftps_required);
     let event_handler_chain = handle_with_logging::<S, U, _>(logger.clone(), event_handler_chain);
 
     let codec = FTPCodec::new();
@@ -219,6 +222,73 @@ where
     Ok(())
 }
 
+fn handle_checking_ftps_requirement<S, U, N>(
+    next: N,
+    session: SharedSession<S, U>,
+    ftps_requirement: FtpsRequired,
+) -> impl Fn(Event) -> Result<Reply, ControlChanError>
+where
+    U: UserDetail + 'static,
+    S: StorageBackend<U> + 'static,
+    S::Metadata: Metadata,
+    N: Fn(Event) -> Result<Reply, ControlChanError>,
+{
+    move |event| match (ftps_requirement, event) {
+        (FtpsRequired::None, event) => next(event),
+        (FtpsRequired::All, event) => match event {
+            Event::Command(Command::CCC) => Ok(Reply::new(ReplyCode::FtpsRequired, "Cannot downgrade connection, TLS enforced.")),
+            Event::Command(Command::User { .. }) | Event::Command(Command::Pass { .. }) => {
+                let is_tls = block_on(async {
+                    let session = session.lock().await;
+                    session.cmd_tls
+                });
+                match is_tls {
+                    true => next(event),
+                    false => Ok(Reply::new(ReplyCode::FtpsRequired, "A TLS connection is required")),
+                }
+            }
+            _ => next(event),
+        },
+        (FtpsRequired::Logins, event) => {
+            let (is_tls, username) = block_on(async {
+                let session = session.lock().await;
+                (session.cmd_tls, session.username.clone())
+            });
+            match (is_tls, event) {
+                (true, event) => next(event),
+                (false, Event::Command(Command::User { username })) => {
+                    if is_anonymous_user(&username[..])? {
+                        next(Event::Command(Command::User { username }))
+                    } else {
+                        Ok(Reply::new(ReplyCode::FtpsRequired, "A TLS connection is required"))
+                    }
+                }
+                (false, Event::Command(Command::Pass { password })) => {
+                    match username {
+                        None => {
+                            // Should not happen, username should have already been provided.
+                            Err(ControlChanError::new(ControlChanErrorKind::IllegalState))
+                        }
+                        Some(username) => {
+                            if is_anonymous_user(username)? {
+                                next(Event::Command(Command::Pass { password }))
+                            } else {
+                                Ok(Reply::new(ReplyCode::FtpsRequired, "A TLS connection is required"))
+                            }
+                        }
+                    }
+                }
+                (false, event) => next(event),
+            }
+        }
+    }
+}
+
+fn is_anonymous_user(username: impl AsRef<[u8]>) -> Result<bool, std::str::Utf8Error> {
+    let username_str = std::str::from_utf8(username.as_ref())?;
+    Ok(username_str == "anonymous")
+}
+
 fn handle_with_auth<S, U, N>(session: SharedSession<S, U>, next: N) -> impl Fn(Event) -> Result<Reply, ControlChanError>
 where
     U: UserDetail + 'static,
@@ -237,18 +307,15 @@ where
         | Event::Command(Command::Noop)
         | Event::Command(Command::Quit) => next(event),
         _ => {
-            let r = block_on(async {
+            let session_state = block_on(async {
                 let session = session.lock().await;
-                if session.state != SessionState::WaitCmd {
-                    Ok(Reply::new(ReplyCode::NotLoggedIn, "Please authenticate"))
-                } else {
-                    Err(())
-                }
+                session.state
             });
-            if let Ok(r) = r {
-                return Ok(r);
+            if session_state != SessionState::WaitCmd {
+                Ok(Reply::new(ReplyCode::NotLoggedIn, "Please authenticate"))
+            } else {
+                next(event)
             }
-            next(event)
         }
     }
 }

--- a/src/server/controlchan/error.rs
+++ b/src/server/controlchan/error.rs
@@ -48,6 +48,9 @@ pub enum ControlChanErrorKind {
     /// The timer on the Control Channel elapsed.
     #[fail(display = "Encountered read timeout on the control channel")]
     ControlChannelTimeout,
+    /// The control channel is out of sync e.g. expecting username in session after USER command but found none.
+    #[fail(display = "Control channel in illegal state")]
+    IllegalState,
 }
 
 impl ControlChanError {

--- a/src/server/controlchan/reply.rs
+++ b/src/server/controlchan/reply.rs
@@ -87,6 +87,7 @@ pub enum ReplyCode {
     CommandNotImplementedForParameter = 504,
     NotLoggedIn = 530,
     NeedAccountToStore = 532,
+    FtpsRequired = 534, // Could Not Connect to Server - Policy Requires SSL
     FileError = 550,
     PageTypeUnknown = 551,
     ExceededStorageAllocation = 552,

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -27,7 +27,7 @@ impl std::fmt::Display for TraceId {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum SessionState {
     New,
     WaitPass,


### PR DESCRIPTION
This implements the control channel part of #248 by adding an option in libunftp to enforce the use of TLS. The option can be one of 3:

- All - Require all users to use TLS
- Logins - Require all users except anonymous users to use TLS.
- None - TLS not enforced.