### PR TITLE
API renames

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,7 +5,7 @@ pub async fn main() {
     pretty_env_logger::init();
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::new_with_fs_root(std::env::temp_dir());
+    let server = libunftp::Server::with_fs(std::env::temp_dir());
 
     info!("Starting ftp server on {}", addr);
     server.listen(addr).await;

--- a/examples/jsonfile_auth.rs
+++ b/examples/jsonfile_auth.rs
@@ -8,7 +8,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let authenticator = jsonfile::JsonFileAuthenticator::new(String::from("credentials.json"))?;
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::new_with_fs_root(std::env::temp_dir()).authenticator(Arc::new(authenticator));
+    let server = libunftp::Server::with_fs(std::env::temp_dir()).authenticator(Arc::new(authenticator));
 
     info!("Starting ftp server on {}", addr);
     let mut runtime = tokio::runtime::Builder::new().build().unwrap();

--- a/examples/proxyprotocol.rs
+++ b/examples/proxyprotocol.rs
@@ -5,7 +5,7 @@ pub async fn main() {
     pretty_env_logger::init();
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::new_with_fs_root(std::env::temp_dir()).proxy_protocol_mode(2121);
+    let server = libunftp::Server::with_fs(std::env::temp_dir()).proxy_protocol_mode(2121);
 
     info!("Starting ftp server with proxy protocol on {}", addr);
     server.listen(addr).await;

--- a/examples/rest.rs
+++ b/examples/rest.rs
@@ -20,7 +20,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::new_with_fs_root(std::env::temp_dir()).authenticator(Arc::new(authenticator));
+    let server = libunftp::Server::with_fs(std::env::temp_dir()).authenticator(Arc::new(authenticator));
 
     info!("Starting ftp server on {}", addr);
     let mut runtime = Builder::new().build()?;

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -49,7 +49,7 @@
 //! ```
 //! # // Make it compile
 //! # type RandomAuthenticator = libunftp::auth::AnonymousAuthenticator;
-//! let server = libunftp::Server::new_with_fs_and_auth(
+//! let server = libunftp::Server::with_fs_and_auth(
 //!   "/srv/ftp",
 //!   std::sync::Arc::new(RandomAuthenticator{})
 //! );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! #[tokio::main]
 //! pub async fn main() {
 //!     let ftp_home = std::env::temp_dir();
-//!     let server = libunftp::Server::new_with_fs_root(ftp_home)
+//!     let server = libunftp::Server::with_fs(ftp_home)
 //!         .greeting("Welcome to my FTP server")
 //!         .passive_ports(50000..65535);
 //!

--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -249,7 +249,7 @@ where
             }
             _ => next(event),
         },
-        (FtpsRequired::Logins, event) => {
+        (FtpsRequired::Accounts, event) => {
             let (is_tls, username) = block_on(async {
                 let session = session.lock().await;
                 (session.cmd_tls, session.username.clone())

--- a/src/server/ftpserver/options.rs
+++ b/src/server/ftpserver/options.rs
@@ -59,8 +59,8 @@ impl From<&str> for PassiveHost {
 pub enum FtpsRequired {
     /// All users, including anonymous must use FTPS
     All,
-    /// All non-anynymous users requires FTPS.
-    Logins,
+    /// All non-anonymous users requires FTPS.
+    Accounts,
     /// FTPS not enforced.
     None, // would be nice to have a per-user setting also.
 }
@@ -83,7 +83,7 @@ impl Display for FtpsRequired {
             "{}",
             match self {
                 FtpsRequired::All => "All users, including anonymous, requires FTPS",
-                FtpsRequired::Logins => "All non-anonymous users requires FTPS",
+                FtpsRequired::Accounts => "All non-anonymous users requires FTPS",
                 FtpsRequired::None => "FTPS not enforced",
             }
         )

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -25,7 +25,7 @@ fn ensure_ftps_required<T: Debug>(r: Result<T>) {
 async fn connect() {
     let addr: &str = "127.0.0.1:1234";
     let path: PathBuf = std::env::temp_dir();
-    tokio::spawn(libunftp::Server::new_with_fs_root(path).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(path).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     async_ftp::FtpStream::connect(addr).await.unwrap();
 }
@@ -37,7 +37,7 @@ async fn login() {
     let username = "koen";
     let password = "hoi";
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(path).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(path).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     let mut ftp_stream = async_ftp::FtpStream::connect(addr).await.unwrap();
     ftp_stream.login(username, password).await.unwrap();
@@ -79,13 +79,13 @@ async fn ftps_require_works() {
         },
         Test {
             username: "AnonyMous",
-            mode: FtpsRequired::Logins,
+            mode: FtpsRequired::Accounts,
             give534: false,
             port: 1254,
         },
         Test {
             username: "the-user",
-            mode: FtpsRequired::Logins,
+            mode: FtpsRequired::Accounts,
             give534: true,
             port: 1255,
         },
@@ -97,11 +97,7 @@ async fn ftps_require_works() {
         // stream or something.
         let addr = format!("127.0.0.1:{}", test.port);
 
-        tokio::spawn(
-            libunftp::Server::new_with_fs_root(std::env::temp_dir())
-                .ftps_required(test.mode)
-                .listen(addr.clone()),
-        );
+        tokio::spawn(libunftp::Server::with_fs(std::env::temp_dir()).ftps_required(test.mode).listen(addr.clone()));
         tokio::time::delay_for(Duration::new(1, 0)).await;
 
         let mut ftp_stream = async_ftp::FtpStream::connect(addr.as_str()).await.unwrap();
@@ -117,7 +113,7 @@ async fn noop() {
     let addr = "127.0.0.1:1236";
     let path = std::env::temp_dir();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(path).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(path).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     let mut ftp_stream = async_ftp::FtpStream::connect(addr).await.unwrap();
 
@@ -132,7 +128,7 @@ async fn get() {
     let path = std::env::temp_dir();
     let mut filename = path.clone();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(path).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(path).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     // Create a temporary file in the FTP root that we'll retrieve
     filename.push("bla.txt");
@@ -164,7 +160,7 @@ async fn put() {
     let addr = "127.0.0.1:1238";
     let path = std::env::temp_dir();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(path).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(path).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
 
     let content = b"Hello from this test!\n";
@@ -187,7 +183,7 @@ async fn list() {
     let addr = "127.0.0.1:1239";
     let root = std::env::temp_dir();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(root.clone()).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(root.clone()).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     // Create a filename in the ftp root that we will look for in the `LIST` output
     let path = root.join("test.txt");
@@ -216,7 +212,7 @@ async fn pwd() {
     let addr = "127.0.0.1:1240";
     let root = std::env::temp_dir();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(root).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(root).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     let mut ftp_stream = FtpStream::connect(addr).await.unwrap();
 
@@ -234,7 +230,7 @@ async fn cwd() {
     let root = std::env::temp_dir();
     let path = root.clone();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(path.clone()).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(path.clone()).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     let mut ftp_stream = FtpStream::connect(addr).await.unwrap();
     let dir_in_root = tempfile::TempDir::new_in(path).unwrap();
@@ -254,7 +250,7 @@ async fn cdup() {
     let root = std::env::temp_dir();
     let path = root.clone();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(path.clone()).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(path.clone()).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     let mut ftp_stream = FtpStream::connect(addr).await.unwrap();
     let dir_in_root = tempfile::TempDir::new_in(path).unwrap();
@@ -277,7 +273,7 @@ async fn dele() {
     let addr = "127.0.0.1:1243";
     let root = std::env::temp_dir();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(root).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(root).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     let mut ftp_stream = FtpStream::connect(addr).await.unwrap();
     let file_in_root = tempfile::NamedTempFile::new().unwrap();
@@ -295,7 +291,7 @@ async fn quit() {
     let addr = "127.0.0.1:1244";
     let root = std::env::temp_dir();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(root).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(root).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     let mut ftp_stream = FtpStream::connect(addr).await.unwrap();
     ftp_stream.quit().await.unwrap();
@@ -311,7 +307,7 @@ async fn nlst() {
     let root = tempfile::TempDir::new().unwrap().into_path();
     let path = root.clone();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(path.clone()).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(path.clone()).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     // Create a filename that we wanna see in the `NLST` output
     let path = path.join("test.txt");
@@ -333,7 +329,7 @@ async fn mkdir() {
     let addr = "127.0.0.1:1246";
     let root = tempfile::TempDir::new().unwrap().into_path();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(root.clone()).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(root.clone()).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     let mut ftp_stream = FtpStream::connect(addr).await.unwrap();
     let new_dir_name = "hallo";
@@ -353,7 +349,7 @@ async fn rename() {
     let addr = "127.0.0.1:1247";
     let root = tempfile::TempDir::new().unwrap().into_path();
 
-    tokio::spawn(libunftp::Server::new_with_fs_root(root.clone()).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(root.clone()).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
     // Create a file that we will rename
     let full_from = root.join("ikbenhier.txt");
@@ -388,7 +384,7 @@ async fn rename() {
 async fn size() {
     let addr = "127.0.0.1:1248";
     let root = std::env::temp_dir();
-    tokio::spawn(libunftp::Server::new_with_fs_root(root.clone()).listen(addr));
+    tokio::spawn(libunftp::Server::with_fs(root.clone()).listen(addr));
     tokio::time::delay_for(Duration::new(1, 0)).await;
 
     let mut ftp_stream = FtpStream::connect(addr).await.unwrap();


### PR DESCRIPTION
This MR renames some of the constructor methods in the `Server` struct to be in line with the [Rust conventions](https://rust-lang.github.io/api-guidelines/naming.html). Specifically I remove the `new_` method from secondary constructors i.e. `new_with_authenticator` becomes just `with_authenticator`