### PR TITLE
Let Server.listen return errors instead of panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ slog-stdlog = "4.0.0"
 chrono = {version = "0.4.15", features = ["serde"]}
 failure = "0.1.8"
 failure_derive = "0.1.8"
+thiserror = "1.0.20"
 hyper = { version = "0.13.7", optional = true, features= ["runtime", "stream"]}
 percent-encoding = { version = "2.1.0", optional = true }
 serde = { version = "1.0.115", optional = true, features = ["derive"] }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -8,5 +8,5 @@ pub async fn main() {
     let server = libunftp::Server::with_fs(std::env::temp_dir());
 
     info!("Starting ftp server on {}", addr);
-    server.listen(addr).await;
+    server.listen(addr).await.unwrap();
 }

--- a/examples/gcs.rs
+++ b/examples/gcs.rs
@@ -71,13 +71,13 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         }))
         .ftps(ftps_certs_file, ftps_key_file)
         .listen(BIND_ADDRESS)
-        .await;
+        .await?;
     } else {
         libunftp::Server::new(Box::new(move || {
             libunftp::storage::cloud_storage::CloudStorage::new("https://www.googleapis.com", &bucket_name, service_account_key.clone())
         }))
         .listen(BIND_ADDRESS)
-        .await;
+        .await?;
     }
 
     Ok(())

--- a/examples/jsonfile_auth.rs
+++ b/examples/jsonfile_auth.rs
@@ -12,7 +12,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Starting ftp server on {}", addr);
     let mut runtime = tokio::runtime::Builder::new().build().unwrap();
-    runtime.block_on(server.listen(addr));
+    runtime.block_on(server.listen(addr))?;
 
     Ok(())
 }

--- a/examples/proxyprotocol.rs
+++ b/examples/proxyprotocol.rs
@@ -8,5 +8,5 @@ pub async fn main() {
     let server = libunftp::Server::with_fs(std::env::temp_dir()).proxy_protocol_mode(2121);
 
     info!("Starting ftp server with proxy protocol on {}", addr);
-    server.listen(addr).await;
+    server.listen(addr).await.unwrap();
 }

--- a/examples/rest.rs
+++ b/examples/rest.rs
@@ -24,6 +24,6 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Starting ftp server on {}", addr);
     let mut runtime = Builder::new().build()?;
-    runtime.block_on(server.listen(addr));
+    runtime.block_on(server.listen(addr))?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,4 +44,6 @@ pub(crate) mod metrics;
 pub(crate) mod server;
 pub mod storage;
 
-pub use crate::server::ftpserver::{options, Server};
+pub use crate::server::ftpserver::{error::ServerError, options, Server};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/src/server/ftpserver/error.rs
+++ b/src/server/ftpserver/error.rs
@@ -1,0 +1,36 @@
+//! Contains the error type used by `Server`
+
+use crate::BoxError;
+
+use std::net::AddrParseError;
+use thiserror::Error;
+
+/// Error returned by the `Server.listen` method
+#[derive(Error, Debug)]
+#[error("server error: {msg}")]
+pub struct ServerError {
+    msg: String,
+    #[source]
+    source: BoxError,
+}
+
+impl ServerError {
+    fn new<E: std::error::Error + Send + Sync + 'static>(msg: impl Into<String>, source: E) -> ServerError {
+        ServerError {
+            msg: msg.into(),
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<std::net::AddrParseError> for ServerError {
+    fn from(e: AddrParseError) -> Self {
+        ServerError::new("could not parse address", e)
+    }
+}
+
+impl From<std::io::Error> for ServerError {
+    fn from(e: std::io::Error) -> Self {
+        ServerError::new("io error", e)
+    }
+}


### PR DESCRIPTION
This PR addresses the issue where `Server.listen` method would panic if some errors occur. This is not good for libraries. 

Now `Server.listen` will return an error type that the lib user can then handle.