### PR TITLE
Fixed issue where libunftp crashed because some GCS back-end commands…

### DIFF
--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -564,6 +564,7 @@ where
             ErrorKind::TransientFileNotAvailable => Ok(Reply::new(ReplyCode::TransientFileError, "File not found")),
             ErrorKind::PermanentFileNotAvailable => Ok(Reply::new(ReplyCode::FileError, "File not found")),
             ErrorKind::PermissionDenied => Ok(Reply::new(ReplyCode::FileError, "Permission denied")),
+            ErrorKind::CommandNotImplemented => Ok(Reply::new(ReplyCode::CommandNotImplemented, "Command not implemented")),
         },
         CommandChannelReply(reply) => Ok(reply),
     }

--- a/src/storage/cloud_storage/mod.rs
+++ b/src/storage/cloud_storage/mod.rs
@@ -218,18 +218,19 @@ impl<U: Sync + Send + Debug> StorageBackend<U> for CloudStorage {
 
     #[tracing_attributes::instrument]
     async fn rename<P: AsRef<Path> + Send + Debug>(&self, _user: &Option<U>, _from: P, _to: P) -> Result<(), Error> {
-        //TODO: implement this
-        unimplemented!();
+        // TODO: implement this
+        Err(Error::from(ErrorKind::CommandNotImplemented))
     }
 
     #[tracing_attributes::instrument]
     async fn rmd<P: AsRef<Path> + Send + Debug>(&self, _user: &Option<U>, _path: P) -> Result<(), Error> {
-        //TODO: implement this
-        unimplemented!();
+        // TODO: implement this
+        Err(Error::from(ErrorKind::CommandNotImplemented))
     }
 
     #[tracing_attributes::instrument]
     async fn cwd<P: AsRef<Path> + Send + Debug>(&self, _user: &Option<U>, _path: P) -> Result<(), Error> {
+        // TODO: Do we want to check here if the path is a directory?
         Ok(())
     }
 }

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -71,4 +71,7 @@ pub enum ErrorKind {
     ///     File name not allowed.
     #[display(fmt = "553 File name not allowed error")]
     FileNameNotAllowedError,
+    /// 502 The command is not implemented for the storage back-end
+    #[display(fmt = "502 Command not implemented")]
+    CommandNotImplemented,
 }


### PR DESCRIPTION
… were not implemented

**Before:**

libunftp would cause a crash:

![image](https://user-images.githubusercontent.com/2511554/93004591-a8671600-f548-11ea-8c2f-82e72efa3b3e.png)

**After:**

Now a 502 `Command not implemented` is returned to the client.

```
Sep 12 22:29:58.601 INFO Processing control channel event InternalMsg(StorageError(Error { kind: CommandNotImplemented, source: None })), trace-id: 0x3737937cfffc4978, lib: libunftp
```