### PR TITLE
Upgraded to tokio 0.3. Upgrade other libs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,16 +35,17 @@ percent-encoding = { version = "2.1.0", optional = true }
 prometheus = "0.10.0"
 proxy-protocol = {version = "0.1.1"}
 rand = "0.7.3"
-regex = "1.3.9"
+regex = "1.4.1"
 rustls = "0.18.1"
-serde = { version = "1.0.116", optional = true, features = ["derive"] }
-serde_json = { version = "1.0.58", optional = true }
+serde = { version = "1.0.117", optional = true, features = ["derive"] }
+serde_json = { version = "1.0.59", optional = true }
 slog = { version = "2.5.2", features = ["max_level_trace", "release_max_level_info"] }
 slog-stdlog = "4.0.0"
 thiserror = "1.0.21"
-tokio = { version = "0.2.22", features = ["rt-core", "net", "sync", "io-util", "macros", "time", "fs", "blocking"]}
-tokio-rustls = { version = "0.14.1" }
-tokio-util = { version = "0.3.1", features=["codec", "compat"] }
+tokio = { version = "0.3.0", features = ["rt", "net", "sync", "io-util", "macros", "time", "fs"]}
+tokio-compat-02 = { version = "0.1.0", optional = true}
+tokio-rustls = { version = "0.20.0" }
+tokio-util = { version = "0.4.0", features=["codec", "compat"] }
 tracing = "0.1.21"
 tracing-attributes = "0.1.11"
 tracing-futures = { version = "0.2.4", features = ["std", "std-future", "futures-03"]}
@@ -55,21 +56,21 @@ yup-oauth2 = {version = "4.1.2", optional = true}
 pam-auth = { package = "pam", version = "0.7.0", optional = true }
 
 [dev-dependencies]
-async_ftp = "4.0.1"
+async_ftp = "4.0.2"
 clap = "2.33.3"
 log = "0.4.11"
 pretty_assertions = "0.6.1"
 pretty_env_logger = "0.4.0"
 tempfile = "3.1.0"
-tokio = { version = "0.2.22", features = ["rt-threaded"]}
+tokio = { version = "0.3.0", features = ["rt-multi-thread"]}
 tracing-subscriber = "0.2.13"
 
 [features]
 pam_auth = ["pam-auth"]
-rest_auth = ["hyper", "percent-encoding", "serde", "serde_json"]
+rest_auth = ["hyper", "percent-encoding", "serde", "serde_json", "tokio-compat-02"]
 jsonfile_auth = ["serde", "serde_json"]
-cloud_storage = ["oauth2", "mime", "percent-encoding", "hyper", "serde", "serde_json"]
-oauth2 = ["yup-oauth2", "hyper-rustls"]
+cloud_storage = ["oauth2", "mime", "percent-encoding", "hyper", "serde", "serde_json", "tokio-compat-02"]
+oauth2 = ["yup-oauth2", "hyper-rustls", "tokio-compat-02"]
 
 [[example]]
 name = "gcs"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then add the libunftp and tokio crates to your project's dependencies in `Cargo.
 ```toml
 [dependencies]
 libunftp = "0.13.1"
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "0.3", features = ["full"] }
 ```
 
 Now you're ready to develop your server!

--- a/examples/jsonfile_auth.rs
+++ b/examples/jsonfile_auth.rs
@@ -11,7 +11,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = libunftp::Server::with_fs(std::env::temp_dir()).authenticator(Arc::new(authenticator));
 
     info!("Starting ftp server on {}", addr);
-    let mut runtime = tokio::runtime::Builder::new().build().unwrap();
+    let runtime = tokio::runtime::Builder::new_current_thread().build().unwrap();
     runtime.block_on(server.listen(addr))?;
 
     Ok(())

--- a/examples/rest.rs
+++ b/examples/rest.rs
@@ -23,7 +23,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = libunftp::Server::with_fs(std::env::temp_dir()).authenticator(Arc::new(authenticator));
 
     info!("Starting ftp server on {}", addr);
-    let mut runtime = Builder::new().build()?;
+    let runtime = Builder::new_current_thread().build()?;
     runtime.block_on(server.listen(addr))?;
     Ok(())
 }

--- a/src/auth/jsonfile.rs
+++ b/src/auth/jsonfile.rs
@@ -6,7 +6,7 @@ use crate::auth::*;
 use async_trait::async_trait;
 use serde::Deserialize;
 use std::{fs, time::Duration};
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 #[derive(Deserialize, Clone, Debug)]
 struct Credentials {
@@ -56,13 +56,13 @@ impl Authenticator<DefaultUser> for JsonFileAuthenticator {
                     return Ok(DefaultUser {});
                 } else {
                     // punish the failed login with a 1500ms delay before returning the error
-                    delay_for(Duration::from_millis(1500)).await;
+                    sleep(Duration::from_millis(1500)).await;
                     return Err(AuthenticationError::BadPassword);
                 }
             }
         }
         // punish the failed login with a 1500ms delay before returning the error
-        delay_for(Duration::from_millis(1500)).await;
+        sleep(Duration::from_millis(1500)).await;
         Err(AuthenticationError::BadUser)
     }
 }

--- a/src/auth/rest.rs
+++ b/src/auth/rest.rs
@@ -9,6 +9,7 @@ use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use regex::Regex;
 use serde_json::{json, Value};
 use std::string::String;
+use tokio_compat_02::FutureExt;
 
 /// [`Authenticator`] implementation that authenticates against a JSON REST API.
 ///
@@ -138,8 +139,8 @@ impl Authenticator<DefaultUser> for RestAuthenticator {
 
         let client = Client::new();
 
-        let resp = client.request(req).await?;
-        let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+        let resp = client.request(req).compat().await?;
+        let body_bytes = hyper::body::to_bytes(resp.into_body()).compat().await?;
 
         let body: Value = serde_json::from_slice(&body_bytes)?;
         let parsed = match body.pointer(&selector) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! ```toml
 //! [dependencies]
 //! libunftp = "0.13.1"
-//! tokio = { version = "0.2", features = ["full"] }
+//! tokio = { version = "0.3", features = ["full"] }
 //! ```
 //! Now you're ready to develop your server! Add the following to src/main.rs:
 //!

--- a/src/server/controlchan/commands/pasv.rs
+++ b/src/server/controlchan/commands/pasv.rs
@@ -111,7 +111,7 @@ impl Pasv {
 
         let listener = Pasv::try_port_range(args.local_addr, args.passive_ports).await;
 
-        let mut listener = match listener {
+        let listener = match listener {
             Err(_) => return Ok(Reply::new(ReplyCode::CantOpenDataConnection, "No data connection established")),
             Ok(l) => l,
         };

--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -154,7 +154,7 @@ where
         loop {
             #[allow(unused_assignments)]
             let mut incoming = None;
-            let mut timeout_delay = tokio::time::delay_for(idle_session_timeout);
+            let mut timeout_delay = tokio::time::sleep(idle_session_timeout);
             tokio::select! {
                 Some(cmd_result) = command_source.next() => {
                     incoming = Some(cmd_result.map(Event::Command));

--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -248,7 +248,7 @@ where
     };
 
     tokio::spawn(async move {
-        let mut timeout_delay = tokio::time::delay_for(std::time::Duration::from_secs(5 * 60));
+        let mut timeout_delay = tokio::time::sleep(std::time::Duration::from_secs(5 * 60));
         // TODO: Use configured timeout
         tokio::select! {
             Some(command) = data_cmd_rx.next() => {

--- a/src/server/ftpserver.rs
+++ b/src/server/ftpserver.rs
@@ -372,7 +372,7 @@ where
     #[tracing_attributes::instrument]
     async fn listen_normal_mode<T: Into<String> + Debug>(self, bind_address: T) -> std::result::Result<(), ServerError> {
         let addr: std::net::SocketAddr = bind_address.into().parse()?;
-        let mut listener = tokio::net::TcpListener::bind(addr).await?;
+        let listener = tokio::net::TcpListener::bind(addr).await?;
         loop {
             match listener.accept().await {
                 Ok(stream) => {
@@ -404,8 +404,6 @@ where
         // request for a passive listening port.
         let (proxyloop_msg_tx, mut proxyloop_msg_rx): (ProxyLoopSender<S, U>, ProxyLoopReceiver<S, U>) = channel(1);
 
-        let mut incoming = listener.incoming();
-
         loop {
             // The 'proxy loop' handles two kinds of events:
             // - incoming tcp connections originating from the proxy
@@ -413,7 +411,7 @@ where
 
             tokio::select! {
 
-                Some(tcp_stream) = incoming.next() => {
+                Some(tcp_stream) = listener.next() => {
                     let mut tcp_stream = tcp_stream.unwrap();
                     let socket_addr = tcp_stream.peer_addr();
 

--- a/src/server/proxy_protocol.rs
+++ b/src/server/proxy_protocol.rs
@@ -236,9 +236,9 @@ mod tests {
     use std::net::{IpAddr::V4, Ipv4Addr};
     use std::time::Duration;
     use tokio::io::AsyncWriteExt;
-    use tokio::time::delay_for;
+    use tokio::time::sleep;
 
-    async fn listen_server(mut listener: tokio::net::TcpListener) -> tokio::net::TcpStream {
+    async fn listen_server(listener: tokio::net::TcpListener) -> tokio::net::TcpStream {
         listener.accept().await.unwrap().0
     }
 
@@ -303,7 +303,7 @@ mod tests {
         let server = tokio::spawn(async move { super::read_proxy_header(&mut s).await });
         let client = tokio::spawn(async move {
             c.write_all("PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535".as_ref()).await.unwrap();
-            delay_for(Duration::from_millis(100)).await;
+            sleep(Duration::from_millis(100)).await;
             c.write_all("\r\n".as_ref()).await.unwrap();
             c.shutdown(Shutdown::Both).unwrap();
         });

--- a/tests/gcs.rs
+++ b/tests/gcs.rs
@@ -5,6 +5,7 @@ use pretty_assertions::assert_eq;
 use std::process::Command;
 use std::sync::Once;
 use std::{str, time::Duration};
+use tokio_compat_02::FutureExt;
 
 static INIT: Once = Once::new();
 
@@ -41,18 +42,18 @@ async fn newly_created_dir_is_empty() {
     initialize();
     let addr: &str = "127.0.0.1:1234";
 
-    let service_account_key = yup_oauth2::read_service_account_key("tests/resources/gcs_sa_key.json").await.unwrap();
+    let service_account_key = yup_oauth2::read_service_account_key("tests/resources/gcs_sa_key.json").compat().await.unwrap();
     tokio::spawn(
         Server::new(Box::new(move || {
             CloudStorage::new("http://localhost:9081", "test-bucket", service_account_key.clone())
         }))
         .listen(addr),
     );
-    tokio::time::delay_for(Duration::new(1, 0)).await;
-    let mut ftp_stream = FtpStream::connect(addr).await.unwrap();
-    ftp_stream.login("anonymous", "").await.unwrap();
-    ftp_stream.mkdir("mkdir_test").await.unwrap();
-    ftp_stream.cwd("mkdir_test").await.unwrap();
-    let list = ftp_stream.list(None).await.unwrap();
+    tokio::time::sleep(Duration::new(1, 0)).await;
+    let mut ftp_stream = FtpStream::connect(addr).compat().await.unwrap();
+    ftp_stream.login("anonymous", "").compat().await.unwrap();
+    ftp_stream.mkdir("mkdir_test").compat().await.unwrap();
+    ftp_stream.cwd("mkdir_test").compat().await.unwrap();
+    let list = ftp_stream.list(None).compat().await.unwrap();
     assert_eq!(list.len(), 0)
 }


### PR DESCRIPTION
regex 1.3.9 -> 1.4.1
serde 1.0.116 -> 1.0.117
serde-json 1.0.58 -> 1.0.59
tokio 0.2.22 -> 0.3.0
tokio-rustls 0.14.1 -> 0.20.0
tokio-util 0.3.1 -> 0.4.0

I had to add the `tokio-compat-02` crate because hyper and the FTP client we use for testing is not compatible yet with tokio 0.3. You'll see some of the code sprinkled with `.compat()` additions.