### PR TITLE
Fixed issue where the control channel timed out on large file send/receive (#256)

### DIFF
--- a/src/server/chancomms.rs
+++ b/src/server/chancomms.rs
@@ -15,8 +15,7 @@ pub enum DataCommand {
     Abort,
 }
 
-/// InternalMsg represents a status message from the data channel handler to our main (per connection)
-/// control loop.
+/// Messages that can be sent to the control channel loop.
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum InternalMsg {

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -84,6 +84,9 @@ where
     // The starting byte for a STOR or RETR command. Set by the _Restart of Interrupted Transfer (REST)_
     // command to support resume functionality.
     pub start_pos: u64,
+    // Tells if the data loop is running. The control channel need to know if the data channel is
+    // busy so that it doesn't time out while the session is still in progress.
+    pub data_busy: bool,
 }
 
 impl<S, U: Send + Sync + Debug + 'static> Session<S, U>
@@ -111,6 +114,7 @@ where
             data_tls: false,
             collect_metrics: false,
             start_pos: 0,
+            data_busy: false,
         }
     }
 


### PR DESCRIPTION
Closes #256

I implemented this by having a `data_busy` variable in the session and setting this to true on entry in the data loop and to false on exit.