### PR TITLE
feat: match the data channel IP to the control channel IP

### DIFF
--- a/src/server/controlchan/handler.rs
+++ b/src/server/controlchan/handler.rs
@@ -5,7 +5,6 @@ use crate::{
         chancomms::ProxyLoopSender,
         controlchan::{Command, Reply},
         ftpserver::options::PassiveHost,
-        proxy_protocol::ConnectionTuple,
         session::SharedSession,
         InternalMsg,
     },
@@ -43,6 +42,5 @@ where
     pub local_addr: std::net::SocketAddr,
     pub storage_features: u32,
     pub proxyloop_msg_tx: Option<ProxyLoopSender<S, U>>,
-    pub control_connection_info: Option<ConnectionTuple>,
     pub logger: slog::Logger,
 }

--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -280,6 +280,13 @@ where
                         controlcahn_ip,
                         err
                     )
+                } else {
+                    slog::info!(
+                        logger,
+                        "Closing datachannel for ip ({}) that does not match the ip({}) of the control channel.",
+                        datachan_addr.ip(),
+                        controlcahn_ip
+                    )
                 }
                 return;
             }

--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -276,7 +276,7 @@ where
                 let controlcahn_ip = session.source.ip();
                 if controlcahn_ip != datachan_addr.ip() {
                     if let Err(err) = socket.shutdown(std::net::Shutdown::Both) {
-                        slog::info!(
+                        slog::error!(
                             logger,
                             "Couldn't close datachannel for ip ({}) that does not match the ip({}) of the control channel.\n{:?}",
                             datachan_addr.ip(),

--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -295,7 +295,7 @@ where
                 }
             }
             Err(err) => {
-                slog::info!(logger, "Couldn't determine data channel address.\n{:?}", err);
+                slog::error!(logger, "Couldn't determine data channel address.\n{:?}", err);
                 return;
             }
         }

--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -284,7 +284,7 @@ where
                             err
                         )
                     } else {
-                        slog::info!(
+                        slog::warn!(
                             logger,
                             "Closing datachannel for ip ({}) that does not match the ip({}) of the control channel.",
                             datachan_addr.ip(),

--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -45,7 +45,7 @@ where
     Storage::Metadata: Metadata,
     User: UserDetail + 'static,
 {
-    pub async fn execute(mut self, session_arc: SharedSession<Storage, User>) {
+    async fn execute(mut self, session_arc: SharedSession<Storage, User>) {
         let mut data_cmd_rx = self.data_cmd_rx.take().unwrap().fuse();
         let mut data_abort_rx = self.data_abort_rx.take().unwrap().fuse();
         let mut timeout_delay = tokio::time::sleep(std::time::Duration::from_secs(5 * 60));
@@ -267,6 +267,29 @@ where
 {
     // We introduce a block scope here to keep the lock on the session minimal. We basically copy the needed info
     // out and then unlock.
+
+    match socket.peer_addr() {
+        Ok(datachan_addr) => {
+            let controlcahn_ip = session_arc.lock().await.source.ip();
+            if controlcahn_ip != datachan_addr.ip() {
+                if let Err(err) = socket.shutdown(std::net::Shutdown::Both) {
+                    slog::info!(
+                        logger,
+                        "Couldn't close datachannel for ip ({}) that does not match the ip({}) of the control channel.\n{:?}",
+                        datachan_addr.ip(),
+                        controlcahn_ip,
+                        err
+                    )
+                }
+                return;
+            }
+        }
+        Err(err) => {
+            slog::info!(logger, "Couldn't determine data channel address.\n{:?}", err);
+            return;
+        }
+    }
+
     let command_executor = {
         let mut session = session_arc.lock().await;
         let username = session.username.as_ref().cloned().unwrap_or_else(|| String::from("unknown"));

--- a/src/server/proxy_protocol.rs
+++ b/src/server/proxy_protocol.rs
@@ -41,7 +41,7 @@ pub struct ConnectionTuple {
 }
 
 impl ConnectionTuple {
-    pub fn hash(&self) -> String {
+    pub fn key(&self) -> String {
         format!("{}.{}", self.source.ip(), self.destination.port())
     }
 }
@@ -174,7 +174,7 @@ where
     }
 
     pub fn unregister(&mut self, connection: &ConnectionTuple) {
-        let hash = connection.hash();
+        let hash = connection.key();
         match self.switchboard.remove(&hash) {
             Some(_) => (),
             None => {
@@ -185,7 +185,7 @@ where
 
     #[tracing_attributes::instrument]
     pub async fn get_session_by_incoming_data_connection(&mut self, connection: &ConnectionTuple) -> Option<SharedSession<S, U>> {
-        let hash = connection.hash();
+        let hash = connection.key();
 
         match self.switchboard.get(&hash) {
             Some(session) => session.clone(),

--- a/src/server/proxy_protocol.rs
+++ b/src/server/proxy_protocol.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use lazy_static::lazy_static;
 use proxy_protocol::{version1::ProxyAddressFamily, ProxyHeader};
 use rand::{rngs::OsRng, RngCore};
+use std::net::SocketAddr;
 use std::{collections::HashMap, net::IpAddr, ops::Range};
 use tokio::{io::AsyncReadExt, sync::Mutex};
 
@@ -35,20 +36,13 @@ pub enum ProxyError {
 
 #[derive(Debug, Copy, Clone)]
 pub struct ConnectionTuple {
-    pub from_ip: IpAddr,
-    pub from_port: u16,
-    pub to_ip: IpAddr,
-    pub to_port: u16,
+    pub source: SocketAddr,
+    pub destination: SocketAddr,
 }
 
 impl ConnectionTuple {
-    fn new(from_ip: IpAddr, from_port: u16, to_ip: IpAddr, to_port: u16) -> Self {
-        ConnectionTuple {
-            from_ip,
-            from_port,
-            to_ip,
-            to_port,
-        }
+    pub fn hash(&self) -> String {
+        format!("{}.{}", self.source.ip(), self.destination.port())
     }
 }
 
@@ -113,7 +107,10 @@ pub async fn get_peer_from_proxy_header(tcp_stream: &mut tokio::net::TcpStream) 
             ..
         } => {
             if family == ProxyAddressFamily::IPv4 {
-                Ok(ConnectionTuple::new(source, source_port, destination, destination_port))
+                Ok(ConnectionTuple {
+                    source: SocketAddr::new(source, source_port),
+                    destination: SocketAddr::new(destination, destination_port),
+                })
             } else {
                 Err(ProxyError::IPv4Required)
             }
@@ -124,8 +121,8 @@ pub async fn get_peer_from_proxy_header(tcp_stream: &mut tokio::net::TcpStream) 
 
 /// Constructs a hash key based on the source ip and the destination port
 /// in a straightforward consistent way
-pub fn construct_proxy_hash_key(connection: &ConnectionTuple, port: u16) -> String {
-    format!("{}.{}", connection.from_ip, port)
+pub fn construct_proxy_hash_key(source: &IpAddr, port: u16) -> String {
+    format!("{}.{}", source, port)
 }
 
 /// Connect clients to the right data channel
@@ -176,12 +173,8 @@ where
         }
     }
 
-    fn get_hash_with_connection(connection: &ConnectionTuple) -> String {
-        format!("{}.{}", connection.from_ip, connection.to_port)
-    }
-
     pub fn unregister(&mut self, connection: &ConnectionTuple) {
-        let hash = Self::get_hash_with_connection(connection);
+        let hash = connection.hash();
         match self.switchboard.remove(&hash) {
             Some(_) => (),
             None => {
@@ -192,7 +185,7 @@ where
 
     #[tracing_attributes::instrument]
     pub async fn get_session_by_incoming_data_connection(&mut self, connection: &ConnectionTuple) -> Option<SharedSession<S, U>> {
-        let hash = Self::get_hash_with_connection(connection);
+        let hash = connection.hash();
 
         match self.switchboard.get(&hash) {
             Some(session) => session.clone(),
@@ -212,8 +205,8 @@ where
         for _ in 1..10 {
             let port = rng.next_u32() % rng_length as u32 + self.port_range.start as u32;
             let session = session_arc.lock().await;
-            if let Some(conn) = session.control_connection_info {
-                let hash = construct_proxy_hash_key(&conn, port as u16);
+            if session.destination.is_some() {
+                let hash = construct_proxy_hash_key(&session.source.ip(), port as u16);
 
                 match &self.try_and_claim(hash.clone(), session_arc.clone()) {
                     Ok(_) => return Ok(port as u16),


### PR DESCRIPTION
To prevent malicious transfers the data channel IP must be the same as
 the control channel IP. If they don't match up. The data channel will
 be closed and handling will be stopped.