### PR TITLE
Split middleware into its own files

### DIFF
--- a/src/server/controlchan/auth.rs
+++ b/src/server/controlchan/auth.rs
@@ -1,0 +1,54 @@
+use crate::auth::UserDetail;
+use crate::server::controlchan::error::ControlChanError;
+use crate::server::controlchan::middleware::ControlChanMiddleware;
+use crate::server::session::SharedSession;
+use crate::server::{Command, Event, Reply, ReplyCode, SessionState};
+use crate::storage::{Metadata, StorageBackend};
+use async_trait::async_trait;
+
+// AuthMiddleware ensures the user is authenticated before he can do much else.
+pub struct AuthMiddleware<Storage, User, Next>
+where
+    User: UserDetail + 'static,
+    Storage: StorageBackend<User> + 'static,
+    Storage::Metadata: Metadata,
+    Next: ControlChanMiddleware,
+{
+    pub session: SharedSession<Storage, User>,
+    pub next: Next,
+}
+
+#[async_trait]
+impl<Storage, User, Next> ControlChanMiddleware for AuthMiddleware<Storage, User, Next>
+where
+    User: UserDetail + 'static,
+    Storage: StorageBackend<User> + 'static,
+    Storage::Metadata: Metadata,
+    Next: ControlChanMiddleware,
+{
+    async fn handle(&mut self, event: Event) -> Result<Reply, ControlChanError> {
+        match event {
+            // internal messages and the below commands are exempt from auth checks.
+            Event::InternalMsg(_)
+            | Event::Command(Command::Help)
+            | Event::Command(Command::User { .. })
+            | Event::Command(Command::Pass { .. })
+            | Event::Command(Command::Auth { .. })
+            | Event::Command(Command::Feat)
+            | Event::Command(Command::Noop)
+            | Event::Command(Command::Quit) => self.next.handle(event).await,
+            _ => {
+                let session_state = async {
+                    let session = self.session.lock().await;
+                    session.state
+                }
+                .await;
+                if session_state != SessionState::WaitCmd {
+                    Ok(Reply::new(ReplyCode::NotLoggedIn, "Please authenticate"))
+                } else {
+                    self.next.handle(event).await
+                }
+            }
+        }
+    }
+}

--- a/src/server/controlchan/ftps.rs
+++ b/src/server/controlchan/ftps.rs
@@ -1,0 +1,150 @@
+use async_trait::async_trait;
+
+use crate::{
+    auth::UserDetail,
+    server::{
+        controlchan::error::ControlChanError, controlchan::middleware::ControlChanMiddleware, ftpserver::options::FtpsRequired, session::SharedSession,
+        Command, ControlChanErrorKind, Event, Reply, ReplyCode,
+    },
+    storage::{Metadata, StorageBackend},
+};
+
+// Middleware that enforces FTPS on the control channel according to the specified setting/requirement.
+pub struct FtpsControlChanEnforcerMiddleware<Storage, User, Next>
+where
+    User: UserDetail + 'static,
+    Storage: StorageBackend<User> + 'static,
+    Storage::Metadata: Metadata,
+    Next: ControlChanMiddleware,
+{
+    pub session: SharedSession<Storage, User>,
+    pub ftps_requirement: FtpsRequired,
+    pub next: Next,
+}
+
+#[async_trait]
+impl<Storage, User, Next> ControlChanMiddleware for FtpsControlChanEnforcerMiddleware<Storage, User, Next>
+where
+    User: UserDetail + 'static,
+    Storage: StorageBackend<User> + 'static,
+    Storage::Metadata: Metadata,
+    Next: ControlChanMiddleware,
+{
+    async fn handle(&mut self, event: Event) -> Result<Reply, ControlChanError> {
+        match (self.ftps_requirement, event) {
+            (FtpsRequired::None, event) => self.next.handle(event).await,
+            (FtpsRequired::All, event) => match event {
+                Event::Command(Command::CCC) => Ok(Reply::new(ReplyCode::FtpsRequired, "Cannot downgrade connection, TLS enforced.")),
+                Event::Command(Command::User { .. }) | Event::Command(Command::Pass { .. }) => {
+                    let is_tls = async {
+                        let session = self.session.lock().await;
+                        session.cmd_tls
+                    }
+                    .await;
+                    match is_tls {
+                        true => self.next.handle(event).await,
+                        false => Ok(Reply::new(ReplyCode::FtpsRequired, "A TLS connection is required on the control channel")),
+                    }
+                }
+                _ => self.next.handle(event).await,
+            },
+            (FtpsRequired::Accounts, event) => {
+                let (is_tls, username) = async {
+                    let session = self.session.lock().await;
+                    (session.cmd_tls, session.username.clone())
+                }
+                .await;
+                match (is_tls, event) {
+                    (true, event) => self.next.handle(event).await,
+                    (false, Event::Command(Command::User { username })) => {
+                        if is_anonymous_user(&username[..])? {
+                            self.next.handle(Event::Command(Command::User { username })).await
+                        } else {
+                            Ok(Reply::new(ReplyCode::FtpsRequired, "A TLS connection is required on the control channel"))
+                        }
+                    }
+                    (false, Event::Command(Command::Pass { password })) => {
+                        match username {
+                            None => {
+                                // Should not happen, username should have already been provided.
+                                Err(ControlChanError::new(ControlChanErrorKind::IllegalState))
+                            }
+                            Some(username) => {
+                                if is_anonymous_user(username)? {
+                                    self.next.handle(Event::Command(Command::Pass { password })).await
+                                } else {
+                                    Ok(Reply::new(ReplyCode::FtpsRequired, "A TLS connection is required on the control channel"))
+                                }
+                            }
+                        }
+                    }
+                    (false, event) => self.next.handle(event).await,
+                }
+            }
+        }
+    }
+}
+
+// Middleware that enforces FTPS on the data channel according to the specified setting/requirement.
+pub struct FtpsDataChanEnforcerMiddleware<Storage, User, Next>
+where
+    User: UserDetail + 'static,
+    Storage: StorageBackend<User> + 'static,
+    Storage::Metadata: Metadata,
+    Next: ControlChanMiddleware,
+{
+    pub session: SharedSession<Storage, User>,
+    pub ftps_requirement: FtpsRequired,
+    pub next: Next,
+}
+
+#[async_trait]
+impl<Storage, User, Next> ControlChanMiddleware for FtpsDataChanEnforcerMiddleware<Storage, User, Next>
+where
+    User: UserDetail + 'static,
+    Storage: StorageBackend<User> + 'static,
+    Storage::Metadata: Metadata,
+    Next: ControlChanMiddleware,
+{
+    async fn handle(&mut self, event: Event) -> Result<Reply, ControlChanError> {
+        match (self.ftps_requirement, event) {
+            (FtpsRequired::None, event) => self.next.handle(event).await,
+            (FtpsRequired::All, event) => match event {
+                Event::Command(Command::Pasv) => {
+                    let is_tls = async {
+                        let session = self.session.lock().await;
+                        session.data_tls
+                    }
+                    .await;
+                    match is_tls {
+                        true => self.next.handle(event).await,
+                        false => Ok(Reply::new(ReplyCode::FtpsRequired, "A TLS connection is required on the data channel")),
+                    }
+                }
+                _ => self.next.handle(event).await,
+            },
+            (FtpsRequired::Accounts, event) => match event {
+                Event::Command(Command::Pasv) => {
+                    let (is_tls, username_opt) = async {
+                        let session = self.session.lock().await;
+                        (session.cmd_tls, session.username.clone())
+                    }
+                    .await;
+
+                    let username: String = username_opt.ok_or_else(|| ControlChanError::new(ControlChanErrorKind::IllegalState))?;
+                    let is_anonymous = is_anonymous_user(username)?;
+                    match (is_tls, is_anonymous) {
+                        (true, _) | (false, true) => self.next.handle(event).await,
+                        _ => Ok(Reply::new(ReplyCode::FtpsRequired, "A TLS connection is required on the data channel")),
+                    }
+                }
+                _ => self.next.handle(event).await,
+            },
+        }
+    }
+}
+
+fn is_anonymous_user(username: impl AsRef<[u8]>) -> Result<bool, std::str::Utf8Error> {
+    let username_str = std::str::from_utf8(username.as_ref())?;
+    Ok(username_str == "anonymous")
+}

--- a/src/server/controlchan/log.rs
+++ b/src/server/controlchan/log.rs
@@ -1,0 +1,30 @@
+use crate::server::{
+    controlchan::{error::ControlChanError, middleware::ControlChanMiddleware},
+    Event, Reply,
+};
+
+use async_trait::async_trait;
+
+// Control channel middleware that logs all control channel events
+pub struct LoggingMiddleware<Next>
+where
+    Next: ControlChanMiddleware,
+{
+    pub logger: slog::Logger,
+    pub sequence_nr: u64,
+    pub next: Next,
+}
+
+#[async_trait]
+impl<Next> ControlChanMiddleware for LoggingMiddleware<Next>
+where
+    Next: ControlChanMiddleware,
+{
+    async fn handle(&mut self, event: Event) -> Result<Reply, ControlChanError> {
+        self.sequence_nr += 1;
+        slog::info!(self.logger, "Processing control channel event {:?}", event; "seq" => self.sequence_nr);
+        let result = self.next.handle(event).await;
+        slog::info!(self.logger, "Result of processing control channel event {:?}", result; "seq" => self.sequence_nr);
+        result
+    }
+}

--- a/src/server/controlchan/middleware.rs
+++ b/src/server/controlchan/middleware.rs
@@ -1,0 +1,27 @@
+use crate::server::{
+    controlchan::{error::ControlChanError, Reply},
+    Event,
+};
+use async_trait::async_trait;
+use std::{future::Future, pin::Pin};
+
+// Defines the requirements for code that wants to intercept and do something with control channel events.
+#[async_trait]
+pub trait ControlChanMiddleware: Send + Sync {
+    async fn handle(&mut self, e: Event) -> Result<Reply, ControlChanError>;
+
+    fn name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+}
+
+// Allows plain functions to be middleware. Experimental...
+#[async_trait]
+impl<Function> ControlChanMiddleware for Function
+where
+    Function: Send + Sync + Fn(Event) -> Pin<Box<dyn Future<Output = Result<Reply, ControlChanError>> + Send>>,
+{
+    async fn handle(&mut self, e: Event) -> Result<Reply, ControlChanError> {
+        (self)(e).await
+    }
+}

--- a/src/server/controlchan/mod.rs
+++ b/src/server/controlchan/mod.rs
@@ -22,3 +22,8 @@ pub(crate) use error::ControlChanErrorKind;
 
 mod control_loop;
 pub(crate) use control_loop::{spawn as spawn_loop, Config as LoopConfig};
+
+mod auth;
+mod ftps;
+mod log;
+mod middleware;


### PR DESCRIPTION
This is a cleanup refactoring MR that takes the middleware currently hidden in the control_loop module and split it into its own modules whiles renaming the `EventHandler` trait to a more aptly named `ControlChanMiddleware`

These modules are private now, but hopefully with some thinking and refactoring some of it can even be exposed to the user to allow him to add his own.