### PR TITLE
Cleanup

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Contains the `add...metric` functions that are used for gathering metrics.
 
-use crate::server::{Command, ControlChanErrorKind, Event, InternalMsg, Reply, ReplyCode};
+use crate::server::{Command, ControlChanErrorKind, ControlChanMsg, Event, Reply, ReplyCode};
 
 use lazy_static::*;
 use prometheus::{opts, register_int_counter, register_int_counter_vec, register_int_gauge, IntCounter, IntCounterVec, IntGauge};
@@ -29,11 +29,11 @@ pub fn add_event_metric(event: &Event) {
             add_command_metric(&cmd);
         }
         Event::InternalMsg(msg) => match msg {
-            InternalMsg::SendData { bytes } => {
+            ControlChanMsg::SendData { bytes } => {
                 FTP_BACKEND_READ_BYTES.inc_by(*bytes);
                 FTP_BACKEND_READ_FILES.inc();
             }
-            InternalMsg::WrittenData { bytes } => {
+            ControlChanMsg::WrittenData { bytes } => {
                 FTP_BACKEND_WRITE_BYTES.inc_by(*bytes);
                 FTP_BACKEND_WRITE_FILES.inc();
             }

--- a/src/server/chancomms.rs
+++ b/src/server/chancomms.rs
@@ -1,6 +1,6 @@
 //! Contains code pertaining to the communication between the data and control channels.
 
-use super::{controlchan::command::Command, session::SharedSession};
+use super::session::SharedSession;
 use crate::{
     auth::UserDetail,
     server::controlchan::Reply,
@@ -10,15 +10,37 @@ use futures::channel::mpsc::{Receiver, Sender};
 
 // Commands that can be send to the data channel / data loop.
 #[derive(PartialEq, Debug)]
-pub enum DataCommand {
-    ExternalCommand(Command),
+pub enum DataChanMsg {
+    ExternalCommand(DataChanCmd),
     Abort,
+}
+
+#[derive(PartialEq, Debug)]
+pub enum DataChanCmd {
+    Retr {
+        /// The path to the file the client would like to retrieve.
+        path: String,
+    },
+    Stor {
+        /// The path to the file the client would like to store.
+        path: String,
+    },
+    List {
+        /// Arguments passed along with the list command.
+        options: Option<String>,
+        /// The path of the file/directory the clients wants to list
+        path: Option<String>,
+    },
+    Nlst {
+        /// The path of the file/directory the clients wants to list.
+        path: Option<String>,
+    },
 }
 
 /// Messages that can be sent to the control channel loop.
 #[derive(Debug)]
 #[allow(dead_code)]
-pub enum InternalMsg {
+pub enum ControlChanMsg {
     /// Permission Denied
     PermissionDenied,
     /// File not found

--- a/src/server/controlchan/auth.rs
+++ b/src/server/controlchan/auth.rs
@@ -1,9 +1,13 @@
-use crate::auth::UserDetail;
-use crate::server::controlchan::error::ControlChanError;
-use crate::server::controlchan::middleware::ControlChanMiddleware;
-use crate::server::session::SharedSession;
-use crate::server::{Command, Event, Reply, ReplyCode, SessionState};
-use crate::storage::{Metadata, StorageBackend};
+use crate::{
+    auth::UserDetail,
+    server::{
+        controlchan::{error::ControlChanError, middleware::ControlChanMiddleware},
+        session::SharedSession,
+        {Command, Event, Reply, ReplyCode, SessionState},
+    },
+    storage::{Metadata, StorageBackend},
+};
+
 use async_trait::async_trait;
 
 // AuthMiddleware ensures the user is authenticated before he can do much else.

--- a/src/server/controlchan/commands/auth.rs
+++ b/src/server/controlchan/commands/auth.rs
@@ -7,7 +7,7 @@
 use crate::{
     auth::UserDetail,
     server::{
-        chancomms::InternalMsg,
+        chancomms::ControlChanMsg,
         controlchan::{
             error::ControlChanError,
             handler::{CommandContext, CommandHandler},
@@ -51,7 +51,7 @@ where
         match (args.tls_configured, self.protocol.clone()) {
             (true, AuthParam::Tls) => {
                 tokio::spawn(async move {
-                    if let Err(err) = tx.send(InternalMsg::SecureControlChannel).await {
+                    if let Err(err) = tx.send(ControlChanMsg::SecureControlChannel).await {
                         slog::warn!(logger, "{}", err);
                     }
                 });

--- a/src/server/controlchan/commands/cwd.rs
+++ b/src/server/controlchan/commands/cwd.rs
@@ -10,7 +10,7 @@
 use crate::{
     auth::UserDetail,
     server::{
-        chancomms::InternalMsg,
+        chancomms::ControlChanMsg,
         controlchan::{
             error::ControlChanError,
             handler::{CommandContext, CommandHandler},
@@ -52,12 +52,12 @@ where
 
         if let Err(err) = storage.cwd(&session.user, path.clone()).await {
             slog::warn!(logger, "Failed to cwd directory: {}", err);
-            let r = tx_fail.send(InternalMsg::StorageError(err)).await;
+            let r = tx_fail.send(ControlChanMsg::StorageError(err)).await;
             if let Err(e) = r {
                 slog::warn!(logger, "Could not send internal message to notify of CWD error: {}", e);
             }
         } else {
-            let r = tx_success.send(InternalMsg::CwdSuccess).await;
+            let r = tx_success.send(ControlChanMsg::CwdSuccess).await;
             session.cwd.push(path);
             if let Err(e) = r {
                 slog::warn!(logger, "Could not send internal message to notify of CWD success: {}", e);

--- a/src/server/controlchan/commands/dele.rs
+++ b/src/server/controlchan/commands/dele.rs
@@ -8,7 +8,7 @@
 use crate::{
     auth::UserDetail,
     server::{
-        chancomms::InternalMsg,
+        chancomms::ControlChanMsg,
         controlchan::{
             error::ControlChanError,
             handler::{CommandContext, CommandHandler},
@@ -45,18 +45,18 @@ where
         let storage = Arc::clone(&session.storage);
         let user = session.user.clone();
         let path = session.cwd.join(self.path.clone());
-        let mut tx_success: Sender<InternalMsg> = args.tx.clone();
-        let mut tx_fail: Sender<InternalMsg> = args.tx.clone();
+        let mut tx_success: Sender<ControlChanMsg> = args.tx.clone();
+        let mut tx_fail: Sender<ControlChanMsg> = args.tx.clone();
         let logger = args.logger;
         tokio::spawn(async move {
             match storage.del(&user, path).await {
                 Ok(_) => {
-                    if let Err(err) = tx_success.send(InternalMsg::DelSuccess).await {
+                    if let Err(err) = tx_success.send(ControlChanMsg::DelSuccess).await {
                         slog::warn!(logger, "{}", err);
                     }
                 }
                 Err(err) => {
-                    if let Err(err) = tx_fail.send(InternalMsg::StorageError(err)).await {
+                    if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(err)).await {
                         slog::warn!(logger, "{}", err);
                     }
                 }

--- a/src/server/controlchan/commands/list.rs
+++ b/src/server/controlchan/commands/list.rs
@@ -13,6 +13,7 @@
 // to system, this information may be hard to use automatically
 // in a program, but may be quite useful to a human user.
 
+use crate::server::chancomms::DataChanCmd;
 use crate::{
     auth::UserDetail,
     server::controlchan::{
@@ -38,7 +39,10 @@ where
     #[tracing_attributes::instrument]
     async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
-        let cmd: Command = args.cmd.clone();
+        let cmd: DataChanCmd = match args.cmd.clone() {
+            Command::List { path, options } => DataChanCmd::List { path, options },
+            _ => panic!("Programmer error, expected command to be LIST"),
+        };
         let logger = args.logger;
         match session.data_cmd_tx.take() {
             Some(mut tx) => {

--- a/src/server/controlchan/commands/mdtm.rs
+++ b/src/server/controlchan/commands/mdtm.rs
@@ -1,7 +1,7 @@
 use crate::{
     auth::UserDetail,
     server::{
-        chancomms::InternalMsg,
+        chancomms::ControlChanMsg,
         controlchan::{
             error::ControlChanError,
             handler::{CommandContext, CommandHandler},
@@ -41,8 +41,8 @@ where
         let user = session.user.clone();
         let storage = Arc::clone(&session.storage);
         let path = session.cwd.join(self.path.clone());
-        let mut tx_success: Sender<InternalMsg> = args.tx.clone();
-        let mut tx_fail: Sender<InternalMsg> = args.tx.clone();
+        let mut tx_success: Sender<ControlChanMsg> = args.tx.clone();
+        let mut tx_fail: Sender<ControlChanMsg> = args.tx.clone();
         let logger = args.logger;
 
         tokio::spawn(async move {
@@ -51,7 +51,7 @@ where
                     let modification_time = match metadata.modified() {
                         Ok(v) => Some(v),
                         Err(err) => {
-                            if let Err(err) = tx_fail.send(InternalMsg::StorageError(err)).await {
+                            if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(err)).await {
                                 slog::warn!(logger, "{}", err);
                             };
                             None
@@ -60,7 +60,7 @@ where
 
                     if let Some(mtime) = modification_time {
                         if let Err(err) = tx_success
-                            .send(InternalMsg::CommandChannelReply(Reply::new_with_string(
+                            .send(ControlChanMsg::CommandChannelReply(Reply::new_with_string(
                                 ReplyCode::FileStatus,
                                 DateTime::<Utc>::from(mtime).format(RFC3659_TIME).to_string(),
                             )))
@@ -71,7 +71,7 @@ where
                     }
                 }
                 Err(err) => {
-                    if let Err(err) = tx_fail.send(InternalMsg::StorageError(err)).await {
+                    if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(err)).await {
                         slog::warn!(logger, "{}", err);
                     }
                 }

--- a/src/server/controlchan/commands/mkd.rs
+++ b/src/server/controlchan/commands/mkd.rs
@@ -8,7 +8,7 @@
 use crate::{
     auth::UserDetail,
     server::{
-        chancomms::InternalMsg,
+        chancomms::ControlChanMsg,
         controlchan::{
             error::ControlChanError,
             handler::{CommandContext, CommandHandler},
@@ -45,15 +45,15 @@ where
         let user = session.user.clone();
         let storage = Arc::clone(&session.storage);
         let path: PathBuf = session.cwd.join(self.path.clone());
-        let mut tx_success: Sender<InternalMsg> = args.tx.clone();
-        let mut tx_fail: Sender<InternalMsg> = args.tx.clone();
+        let mut tx_success: Sender<ControlChanMsg> = args.tx.clone();
+        let mut tx_fail: Sender<ControlChanMsg> = args.tx.clone();
         let logger = args.logger;
         tokio::spawn(async move {
             if let Err(err) = storage.mkd(&user, &path).await {
-                if let Err(err) = tx_fail.send(InternalMsg::StorageError(err)).await {
+                if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(err)).await {
                     slog::warn!(logger, "{}", err);
                 }
-            } else if let Err(err) = tx_success.send(InternalMsg::MkdirSuccess(path)).await {
+            } else if let Err(err) = tx_success.send(ControlChanMsg::MkdirSuccess(path)).await {
                 slog::warn!(logger, "{}", err);
             }
         });

--- a/src/server/controlchan/commands/nlst.rs
+++ b/src/server/controlchan/commands/nlst.rs
@@ -13,6 +13,7 @@
 // further process the files automatically.  For example, in
 // the implementation of a "multiple get" function.
 
+use crate::server::chancomms::DataChanCmd;
 use crate::{
     auth::UserDetail,
     server::controlchan::{
@@ -39,7 +40,10 @@ where
     #[tracing_attributes::instrument]
     async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
-        let cmd: Command = args.cmd.clone();
+        let cmd: DataChanCmd = match args.cmd.clone() {
+            Command::Nlst { path } => DataChanCmd::Nlst { path },
+            _ => panic!("Programmer error, expected command to be NLST"),
+        };
         let logger = args.logger;
         match session.data_cmd_tx.take() {
             Some(mut tx) => {

--- a/src/server/controlchan/commands/pass.rs
+++ b/src/server/controlchan/commands/pass.rs
@@ -13,7 +13,7 @@
 use crate::{
     auth::UserDetail,
     server::{
-        chancomms::InternalMsg,
+        chancomms::ControlChanMsg,
         controlchan::{
             error::ControlChanError,
             handler::{CommandContext, CommandHandler},
@@ -61,7 +61,7 @@ where
                         return Ok(Reply::new(ReplyCode::NotLoggedIn, "Please open a new connection to re-authenticate"));
                     }
                 };
-                let mut tx: Sender<InternalMsg> = args.tx.clone();
+                let mut tx: Sender<ControlChanMsg> = args.tx.clone();
 
                 let auther = args.authenticator.clone();
 
@@ -75,13 +75,13 @@ where
                                 let mut session = session2clone.lock().await;
                                 slog::info!(logger, "User {} logged in", user);
                                 session.user = Arc::new(Some(user));
-                                InternalMsg::AuthSuccess
+                                ControlChanMsg::AuthSuccess
                             } else {
                                 slog::warn!(logger, "User {} authenticated but account is disabled", user);
-                                InternalMsg::AuthFailed
+                                ControlChanMsg::AuthFailed
                             }
                         }
-                        Err(_) => InternalMsg::AuthFailed,
+                        Err(_) => ControlChanMsg::AuthFailed,
                     };
                     tokio::spawn(async move {
                         if let Err(err) = tx.send(msg).await {

--- a/src/server/controlchan/commands/quit.rs
+++ b/src/server/controlchan/commands/quit.rs
@@ -15,7 +15,7 @@
 use crate::{
     auth::UserDetail,
     server::{
-        chancomms::InternalMsg,
+        chancomms::ControlChanMsg,
         controlchan::{
             error::ControlChanError,
             handler::{CommandContext, CommandHandler},
@@ -39,10 +39,10 @@ where
 {
     #[tracing_attributes::instrument]
     async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
-        let mut tx: Sender<InternalMsg> = args.tx.clone();
+        let mut tx: Sender<ControlChanMsg> = args.tx.clone();
         let logger = args.logger;
         //TODO does this make sense? The command is not sent and yet an Ok is replied
-        if let Err(send_res) = tx.send(InternalMsg::Quit).await {
+        if let Err(send_res) = tx.send(ControlChanMsg::Quit).await {
             slog::warn!(logger, "could not send internal message: QUIT. {}", send_res);
         }
         Ok(Reply::new(ReplyCode::ClosingControlConnection, "Bye!"))

--- a/src/server/controlchan/commands/retr.rs
+++ b/src/server/controlchan/commands/retr.rs
@@ -8,6 +8,7 @@
 use crate::{
     auth::UserDetail,
     server::{
+        chancomms::DataChanCmd,
         controlchan::{
             command::Command,
             error::{ControlChanError, ControlChanErrorKind},
@@ -34,7 +35,10 @@ where
     #[tracing_attributes::instrument]
     async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
-        let cmd: Command = args.cmd.clone();
+        let cmd: DataChanCmd = match args.cmd.clone() {
+            Command::Retr { path } => DataChanCmd::Retr { path },
+            _ => panic!("Programmer error, expected command to be RETR"),
+        };
         let logger = args.logger;
         match session.data_cmd_tx.take() {
             Some(mut tx) => {

--- a/src/server/controlchan/commands/rmd.rs
+++ b/src/server/controlchan/commands/rmd.rs
@@ -8,7 +8,7 @@
 use crate::{
     auth::UserDetail,
     server::{
-        chancomms::InternalMsg,
+        chancomms::ControlChanMsg,
         controlchan::{
             error::ControlChanError,
             handler::{CommandContext, CommandHandler},
@@ -49,12 +49,12 @@ where
         let logger = args.logger;
         if let Err(err) = storage.rmd(&session.user, path).await {
             slog::warn!(logger, "Failed to delete directory: {}", err);
-            let r = tx_fail.send(InternalMsg::StorageError(err)).await;
+            let r = tx_fail.send(ControlChanMsg::StorageError(err)).await;
             if let Err(e) = r {
                 slog::warn!(logger, "Could not send internal message to notify of RMD error: {}", e);
             }
         } else {
-            let r = tx_success.send(InternalMsg::DelSuccess).await;
+            let r = tx_success.send(ControlChanMsg::DelSuccess).await;
             if let Err(e) = r {
                 slog::warn!(logger, "Could not send internal message to notify of RMD success: {}", e);
             }

--- a/src/server/controlchan/commands/size.rs
+++ b/src/server/controlchan/commands/size.rs
@@ -1,7 +1,7 @@
 use crate::{
     auth::UserDetail,
     server::{
-        chancomms::InternalMsg,
+        chancomms::ControlChanMsg,
         controlchan::{
             error::ControlChanError,
             handler::{CommandContext, CommandHandler},
@@ -39,15 +39,15 @@ where
         let start_pos: u64 = session.start_pos;
         let storage: Arc<S> = Arc::clone(&session.storage);
         let path = session.cwd.join(self.path.clone());
-        let mut tx_success: Sender<InternalMsg> = args.tx.clone();
-        let mut tx_fail: Sender<InternalMsg> = args.tx.clone();
+        let mut tx_success: Sender<ControlChanMsg> = args.tx.clone();
+        let mut tx_fail: Sender<ControlChanMsg> = args.tx.clone();
         let logger = args.logger;
 
         tokio::spawn(async move {
             match storage.metadata(&user, &path).await {
                 Ok(metadata) => {
                     if let Err(err) = tx_success
-                        .send(InternalMsg::CommandChannelReply(Reply::new_with_string(
+                        .send(ControlChanMsg::CommandChannelReply(Reply::new_with_string(
                             ReplyCode::FileStatus,
                             (metadata.len() - start_pos).to_string(),
                         )))
@@ -57,7 +57,7 @@ where
                     }
                 }
                 Err(err) => {
-                    if let Err(err) = tx_fail.send(InternalMsg::StorageError(err)).await {
+                    if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(err)).await {
                         slog::warn!(logger, "{}", err);
                     }
                 }

--- a/src/server/controlchan/commands/stat.rs
+++ b/src/server/controlchan/commands/stat.rs
@@ -20,7 +20,7 @@
 use crate::{
     auth::UserDetail,
     server::{
-        chancomms::InternalMsg,
+        chancomms::ControlChanMsg,
         controlchan::{
             error::ControlChanError,
             handler::{CommandContext, CommandHandler},
@@ -68,8 +68,8 @@ where
                 let user = session.user.clone();
                 let storage = Arc::clone(&session.storage);
 
-                let mut tx_success: Sender<InternalMsg> = args.tx.clone();
-                let mut tx_fail: Sender<InternalMsg> = args.tx.clone();
+                let mut tx_success: Sender<ControlChanMsg> = args.tx.clone();
+                let mut tx_fail: Sender<ControlChanMsg> = args.tx.clone();
                 let logger = args.logger;
 
                 tokio::spawn(async move {
@@ -79,7 +79,7 @@ where
                             match cursor.read_to_string(&mut result) {
                                 Ok(_) => {
                                     if let Err(err) = tx_success
-                                        .send(InternalMsg::CommandChannelReply(Reply::new_with_string(ReplyCode::CommandOkay, result)))
+                                        .send(ControlChanMsg::CommandChannelReply(Reply::new_with_string(ReplyCode::CommandOkay, result)))
                                         .await
                                     {
                                         slog::warn!(logger, "{}", err);
@@ -89,7 +89,7 @@ where
                             }
                         }
                         Err(e) => {
-                            if let Err(err) = tx_fail.send(InternalMsg::StorageError(Error::new(ErrorKind::LocalError, e))).await {
+                            if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(Error::new(ErrorKind::LocalError, e))).await {
                                 slog::warn!(logger, "{}", err);
                             }
                         }

--- a/src/server/controlchan/commands/stor.rs
+++ b/src/server/controlchan/commands/stor.rs
@@ -8,6 +8,7 @@
 // created at the server site if the file specified in the
 // pathname does not already exist.
 
+use crate::server::chancomms::DataChanCmd;
 use crate::{
     auth::UserDetail,
     server::controlchan::{
@@ -34,7 +35,10 @@ where
     #[tracing_attributes::instrument]
     async fn handle(&self, args: CommandContext<S, U>) -> Result<Reply, ControlChanError> {
         let mut session = args.session.lock().await;
-        let cmd: Command = args.cmd.clone();
+        let cmd: DataChanCmd = match args.cmd.clone() {
+            Command::Stor { path } => DataChanCmd::Stor { path },
+            _ => panic!("Programmer error, expected command to be STOR"),
+        };
         let logger = args.logger;
         match session.data_cmd_tx.take() {
             Some(mut tx) => {

--- a/src/server/controlchan/commands/stou.rs
+++ b/src/server/controlchan/commands/stou.rs
@@ -1,9 +1,9 @@
 //! The RFC 959 Store File Uniquely (`STOU`) command
 
+use crate::server::chancomms::DataChanCmd;
 use crate::{
     auth::UserDetail,
     server::controlchan::{
-        command::Command,
         error::ControlChanError,
         handler::{CommandContext, CommandHandler},
         Reply, ReplyCode,
@@ -36,7 +36,7 @@ where
         match session.data_cmd_tx.take() {
             Some(mut tx) => {
                 tokio::spawn(async move {
-                    if let Err(err) = tx.send(Command::Stor { path }).await {
+                    if let Err(err) = tx.send(DataChanCmd::Stor { path }).await {
                         slog::warn!(logger, "sending command failed. {}", err);
                     }
                 });

--- a/src/server/controlchan/event.rs
+++ b/src/server/controlchan/event.rs
@@ -1,12 +1,13 @@
 use super::command::Command;
-use crate::server::InternalMsg;
+use crate::server::ControlChanMsg;
 
-/// Event represents an `Event` that will be handled by our per-client event loop. It can be either
-/// a command from the client, or a status message from the data channel handler.
+/// Event represents a control channel `Event` that will be handled by our per-client control
+/// channel event loop. It can either be a command from the client or an internal message like a
+/// status message from the data channel handler.
 #[derive(Debug)]
 pub enum Event {
     /// A command from a client (e.g. `USER` or `PASV`)
     Command(Command),
-    /// A status message from the data channel loop
-    InternalMsg(InternalMsg),
+    /// A status message from within the library
+    InternalMsg(ControlChanMsg),
 }

--- a/src/server/controlchan/handler.rs
+++ b/src/server/controlchan/handler.rs
@@ -1,12 +1,11 @@
-use super::error::ControlChanError;
 use crate::{
     auth::{Authenticator, UserDetail},
     server::{
         chancomms::ProxyLoopSender,
-        controlchan::{Command, Reply},
+        controlchan::{error::ControlChanError, Command, Reply},
         ftpserver::options::PassiveHost,
         session::SharedSession,
-        InternalMsg,
+        ControlChanMsg,
     },
     storage::{Metadata, StorageBackend},
 };
@@ -38,7 +37,7 @@ where
     pub tls_configured: bool,
     pub passive_ports: Range<u16>,
     pub passive_host: PassiveHost,
-    pub tx: Sender<InternalMsg>,
+    pub tx: Sender<ControlChanMsg>,
     pub local_addr: std::net::SocketAddr,
     pub storage_features: u32,
     pub proxyloop_msg_tx: Option<ProxyLoopSender<Storage, User>>,

--- a/src/server/ftpserver.rs
+++ b/src/server/ftpserver.rs
@@ -2,7 +2,7 @@ pub mod error;
 pub mod options;
 
 use super::{
-    chancomms::{InternalMsg, ProxyLoopMsg, ProxyLoopReceiver, ProxyLoopSender},
+    chancomms::{ControlChanMsg, ProxyLoopMsg, ProxyLoopReceiver, ProxyLoopSender},
     controlchan::{spawn_loop, LoopConfig},
     datachan::spawn_processing,
     ftpserver::{error::ServerError, options::FtpsRequired},
@@ -505,7 +505,7 @@ where
             let tx_some = session.control_msg_tx.clone();
             if let Some(tx) = tx_some {
                 let mut tx = tx.clone();
-                tx.send(InternalMsg::CommandChannelReply(reply)).await.unwrap();
+                tx.send(ControlChanMsg::CommandChannelReply(reply)).await.unwrap();
             }
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -9,7 +9,7 @@ mod proxy_protocol;
 mod session;
 mod tls;
 
-pub(crate) use chancomms::InternalMsg;
+pub(crate) use chancomms::ControlChanMsg;
 pub(crate) use controlchan::command::Command;
 pub(crate) use controlchan::reply::{Reply, ReplyCode};
 pub(crate) use controlchan::ControlChanErrorKind;

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -1,8 +1,9 @@
 //! The session module implements per-connection session handling and currently also
 //! implements the handling for the *data* channel.
 
-use super::{chancomms::InternalMsg, controlchan::command::Command, tls::FTPSConfig};
+use super::{chancomms::ControlChanMsg, tls::FTPSConfig};
 use crate::auth::UserDetail;
+use crate::server::chancomms::DataChanCmd;
 use crate::{
     metrics,
     storage::{Metadata, StorageBackend},
@@ -60,15 +61,15 @@ where
     pub username: Option<String>,
     pub storage: Arc<Storage>,
     // The control loop uses this to send commands to the data loop
-    pub data_cmd_tx: Option<Sender<Command>>,
+    pub data_cmd_tx: Option<Sender<DataChanCmd>>,
     // The data loop uses this receive messages from the control loop
-    pub data_cmd_rx: Option<Receiver<Command>>,
+    pub data_cmd_rx: Option<Receiver<DataChanCmd>>,
     // The control loop uses this to ask the data loop to exit.
     pub data_abort_tx: Option<Sender<()>>,
     // The data loop listens to this so it can know when to exit.
     pub data_abort_rx: Option<Receiver<()>>,
     // This may not be needed here...
-    pub control_msg_tx: Option<Sender<InternalMsg>>,
+    pub control_msg_tx: Option<Sender<ControlChanMsg>>,
     // The socket address of the client on the control channel
     pub source: SocketAddr,
     // The socket address of the proxy protocol destination
@@ -138,7 +139,7 @@ where
         self
     }
 
-    pub fn control_msg_tx(mut self, sender: Sender<InternalMsg>) -> Self {
+    pub fn control_msg_tx(mut self, sender: Sender<ControlChanMsg>) -> Self {
         self.control_msg_tx = Some(sender);
         self
     }


### PR DESCRIPTION
In this PR I rename `InternalMsg` to `ControlChanMsg` and decouple the data channel message from `Command`

![image](https://user-images.githubusercontent.com/2511554/99092760-dd87f700-25d1-11eb-90e6-b5541d0703f6.png)

All the other changes is just a consequence of this