### PR TITLE
Moved metrics functionality in control_loop.rs to its own middleware

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,7 +1,8 @@
 //! Contains the `add...metric` functions that are used for gathering metrics.
 
-use crate::server::{Command, ControlChanErrorKind, ControlChanMsg, Event, Reply, ReplyCode};
+use crate::server::{Command, ControlChanError, ControlChanErrorKind, ControlChanMiddleware, ControlChanMsg, Event, Reply, ReplyCode};
 
+use async_trait::async_trait;
 use lazy_static::*;
 use prometheus::{opts, register_int_counter, register_int_counter_vec, register_int_gauge, IntCounter, IntCounterVec, IntGauge};
 
@@ -77,4 +78,33 @@ pub fn add_reply_metric(reply: &Reply) {
 fn add_replycode_metric(code: ReplyCode) {
     let range = format!("{}xx", code as u32 / 100 % 10);
     FTP_REPLY_TOTAL.with_label_values(&[&range]).inc();
+}
+
+// Control channel middleware that adds metrics
+pub struct MetricsMiddleware<Next>
+where
+    Next: ControlChanMiddleware,
+{
+    pub collect_metrics: bool,
+    pub next: Next,
+}
+
+#[async_trait]
+impl<Next> ControlChanMiddleware for MetricsMiddleware<Next>
+where
+    Next: ControlChanMiddleware,
+{
+    async fn handle(&mut self, event: Event) -> Result<Reply, ControlChanError> {
+        if self.collect_metrics {
+            add_event_metric(&event);
+        }
+        let result: Result<Reply, ControlChanError> = self.next.handle(event).await;
+        if self.collect_metrics {
+            match &result {
+                Ok(reply) => add_reply_metric(reply),
+                Err(e) => add_error_metric(e.kind()),
+            }
+        }
+        result
+    }
 }

--- a/src/server/controlchan/mod.rs
+++ b/src/server/controlchan/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod reply;
 pub(crate) use reply::{Reply, ReplyCode};
 
 mod error;
-pub(crate) use error::ControlChanErrorKind;
+pub(crate) use error::{ControlChanError, ControlChanErrorKind};
 
 mod control_loop;
 pub(crate) use control_loop::{spawn as spawn_loop, Config as LoopConfig};
@@ -27,3 +27,4 @@ mod auth;
 mod ftps;
 mod log;
 mod middleware;
+pub(crate) use middleware::ControlChanMiddleware;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,7 +1,7 @@
 //! Contains the `Server` struct that is used to configure and control a FTP server instance.
 
 mod chancomms;
-mod controlchan;
+pub(crate) mod controlchan;
 mod datachan;
 pub(crate) mod ftpserver;
 mod password;
@@ -12,6 +12,7 @@ mod tls;
 pub(crate) use chancomms::ControlChanMsg;
 pub(crate) use controlchan::command::Command;
 pub(crate) use controlchan::reply::{Reply, ReplyCode};
-pub(crate) use controlchan::ControlChanErrorKind;
+pub(crate) use controlchan::ControlChanMiddleware;
 pub(crate) use controlchan::Event;
+pub(crate) use controlchan::{ControlChanError, ControlChanErrorKind};
 pub(self) use session::{Session, SessionState};


### PR DESCRIPTION
A simple refactoring with the eventual aim of having none of the core functionality depend on the metrics module.