### PR TITLE
Fixed issue where libunftp bombed out when the client sends a string without trailing \r\n

### DIFF
--- a/src/server/controlchan/command.rs
+++ b/src/server/controlchan/command.rs
@@ -115,6 +115,10 @@ pub enum Command {
     Mdtm {
         file: PathBuf,
     },
+    Other {
+        command_name: String,
+        arguments: String,
+    },
 }
 
 impl fmt::Display for Command {

--- a/src/server/controlchan/error.rs
+++ b/src/server/controlchan/error.rs
@@ -97,7 +97,6 @@ impl From<std::str::Utf8Error> for ControlChanError {
 impl From<ParseError> for ControlChanError {
     fn from(err: ParseError) -> ControlChanError {
         let kind: ControlChanErrorKind = match err.kind().clone() {
-            ParseErrorKind::UnknownCommand { command } => ControlChanErrorKind::UnknownCommand { command },
             ParseErrorKind::InvalidUTF8 => ControlChanErrorKind::UTF8Error,
             ParseErrorKind::InvalidCommand => ControlChanErrorKind::InvalidCommand,
             ParseErrorKind::InvalidToken { .. } => ControlChanErrorKind::UTF8Error,

--- a/src/server/controlchan/line_parser/error.rs
+++ b/src/server/controlchan/line_parser/error.rs
@@ -17,12 +17,6 @@ pub struct ParseError {
 /// [ParseError]: ./struct.ParseError.html
 #[derive(Clone, Eq, PartialEq, Debug, Display)]
 pub enum ParseErrorKind {
-    /// The client issued a command that we don't know about.
-    #[display(fmt = "Unknown command: {}", command)]
-    UnknownCommand {
-        /// The command that we don't know about.
-        command: String,
-    },
     /// The client issued an invalid command (e.g. required parameters are missing).
     #[display(fmt = "Invalid command")]
     InvalidCommand,

--- a/src/server/controlchan/line_parser/parser.rs
+++ b/src/server/controlchan/line_parser/parser.rs
@@ -330,7 +330,11 @@ where
             Command::Mdtm { file }
         }
         _ => {
-            return Err(ParseErrorKind::UnknownCommand { command: cmd_token }.into());
+            let params = parse_to_eol(cmd_params)?;
+            Command::Other {
+                command_name: cmd_token,
+                arguments: String::from_utf8_lossy(&params).to_string(),
+            }
         }
     };
 


### PR DESCRIPTION
This MR addresses an issue where a client sends a line of text without terminating \r\n characters:

```
Ξ ~ →  printf "XX" | nc localhost 2122 | head -n 100
220 Welcome to unFTP
451 Unknown internal server error, please try again later
451 Unknown internal server error, please try again later
451 Unknown internal server error, please try again later
451 Unknown internal server error, please try again later
451 Unknown internal server error, please try again later
451 Unknown internal server error, please try again later
451 Unknown internal server error, please try again later
```

Log from libunftp:

![image](https://user-images.githubusercontent.com/2511554/99783317-9098a900-2b1a-11eb-92b4-f55f32d7f752.png)

![image](https://user-images.githubusercontent.com/2511554/99783326-94c4c680-2b1a-11eb-9bc8-a86ce9735a6d.png)
