### PR TITLE
Canonicalize filesystem root path

### DIFF
--- a/src/storage/filesystem.rs
+++ b/src/storage/filesystem.rs
@@ -34,7 +34,10 @@ impl Filesystem {
     /// of the root. For example, when the `Filesystem` root is set to `/srv/ftp`, and a client
     /// asks for `hello.txt`, the server will send it `/srv/ftp/hello.txt`.
     pub fn new<P: Into<PathBuf>>(root: P) -> Self {
-        Filesystem { root: root.into() }
+        let path = root.into();
+        Filesystem {
+            root: canonicalize(&path).unwrap_or(path),
+        }
     }
 
     /// Returns the full, absolute and canonical path corresponding to the (relative to FTP root)


### PR DESCRIPTION
This fixes the local FTP server example on Windows. It no longer results
in "550 Permanent file not availableile not available".

The problem is that `canonicalize` adds `\\?\` UNC prefix, then the
`real_full_path.starts_with(&self.root)` check will always fail because
`real_full_path` starts with `\\?` while `root` does not.