### PR TITLE
Support non-ASCII file names

### DIFF
--- a/src/server/controlchan/error.rs
+++ b/src/server/controlchan/error.rs
@@ -99,7 +99,6 @@ impl From<ParseError> for ControlChanError {
         let kind: ControlChanErrorKind = match err.kind().clone() {
             ParseErrorKind::InvalidUTF8 => ControlChanErrorKind::UTF8Error,
             ParseErrorKind::InvalidCommand => ControlChanErrorKind::InvalidCommand,
-            ParseErrorKind::InvalidToken { .. } => ControlChanErrorKind::UTF8Error,
             _ => ControlChanErrorKind::InvalidCommand,
         };
         ControlChanError {

--- a/src/server/controlchan/line_parser/error.rs
+++ b/src/server/controlchan/line_parser/error.rs
@@ -20,12 +20,6 @@ pub enum ParseErrorKind {
     /// The client issued an invalid command (e.g. required parameters are missing).
     #[display(fmt = "Invalid command")]
     InvalidCommand,
-    /// An invalid token (e.g. not UTF-8) was encountered while parsing the command.
-    #[display(fmt = "Invalid token while parsing: {}", token)]
-    InvalidToken {
-        /// The Token that is not UTF-8 encoded.
-        token: u8,
-    },
     /// Non-UTF8 character encountered.
     #[display(fmt = "Non-UTF8 character while parsing")]
     InvalidUTF8,

--- a/src/server/controlchan/line_parser/tests.rs
+++ b/src/server/controlchan/line_parser/tests.rs
@@ -339,6 +339,12 @@ fn parse_mkd() {
 }
 
 #[test]
+fn parse_mkd_non_ascii() {
+    let input = "MKD 目录\r\n";
+    assert_eq!(parse(input), Ok(Command::Mkd { path: "目录".into() }));
+}
+
+#[test]
 fn parse_allo() {
     let input = "ALLO\r\n";
     assert_eq!(parse(input), Ok(Command::Allo {}));


### PR DESCRIPTION
Before this change, line_parser::parse_to_eol incorrectly returns
ParseErrorKind::InvalidToken error for valid UTF-8 but non-ASCII
input. That makes it impossible to create non-ASCII files or
directories.

parse_to_eol was added by 44a28645f3c1, at which time the input was &[u8].
Later cc0d2d5692 changed its input to String. A Rust String is already
valid UTF-8 so there is no need to check ASCII or UTF-8 in parse_to_eol.
Dropping the check makes it possible to accept non-ASCII path names.