### PR TITLE
GCS Back-end: Allow the use of Workload Identity to authenticate with Google Cloud Storage (#298)

### DIFF
--- a/examples/gcs.rs
+++ b/examples/gcs.rs
@@ -53,7 +53,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         )
         .get_matches();
 
-    let service_account_key = matches
+    let service_account_key_path = matches
         .value_of(SERVICE_ACCOUNT_KEY)
         .ok_or("Internal error: use of an undefined command line parameter")?;
     let bucket_name = matches
@@ -61,7 +61,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         .ok_or("Internal error: use of an undefined command line parameter")?
         .to_owned();
 
-    let service_account_key = yup_oauth2::read_service_account_key(service_account_key).await?;
+    let service_account_key: Vec<u8> = tokio::fs::read(service_account_key_path).await?;
     if let Some(ftps_certs_file) = matches.value_of(FTPS_CERTS_FILE) {
         let ftps_key_file = matches
             .value_of(FTPS_KEY_FILE)

--- a/src/storage/cloud_storage/options.rs
+++ b/src/storage/cloud_storage/options.rs
@@ -1,0 +1,56 @@
+//! Contains code pertaining to initialization options for the [`Cloud Storage Backend`](super::CloudStorage)
+
+use std::{convert::TryFrom, path::PathBuf};
+use yup_oauth2::ServiceAccountKey;
+
+/// Used with [`CloudStorage::new`](super::CloudStorage::new()) to specify how the storage back-end
+/// will authenticate with Google Cloud Storage.
+#[derive(Debug, PartialEq, Clone)]
+pub enum AuthMethod {
+    /// Authenticate using a private service account key
+    ServiceAccountKey(Vec<u8>),
+    /// Authenticate using GCE [Workload Identity](https://cloud.google.com/blog/products/containers-kubernetes/introducing-workload-identity-better-authentication-for-your-gke-applications)
+    WorkloadIdentity(Option<String>),
+}
+
+impl From<Vec<u8>> for AuthMethod {
+    fn from(service_account_key: Vec<u8>) -> Self {
+        if service_account_key.is_empty() {
+            return AuthMethod::WorkloadIdentity(None);
+        }
+        AuthMethod::ServiceAccountKey(service_account_key)
+    }
+}
+
+impl TryFrom<PathBuf> for AuthMethod {
+    type Error = std::io::Error;
+
+    fn try_from(service_account_key_file: PathBuf) -> Result<Self, Self::Error> {
+        match std::fs::read(service_account_key_file) {
+            Err(e) => Err(e),
+            Ok(v) => Ok(v.into()),
+        }
+    }
+}
+
+impl TryFrom<Option<PathBuf>> for AuthMethod {
+    type Error = std::io::Error;
+
+    fn try_from(service_account_key_file: Option<PathBuf>) -> Result<Self, Self::Error> {
+        match service_account_key_file {
+            Some(p) => AuthMethod::try_from(p),
+            None => Ok(AuthMethod::WorkloadIdentity(None)),
+        }
+    }
+}
+
+impl AuthMethod {
+    pub(super) fn to_service_account_key(&self) -> std::io::Result<ServiceAccountKey> {
+        match self {
+            AuthMethod::WorkloadIdentity(_) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "service account key not chosen as option")),
+            AuthMethod::ServiceAccountKey(key) => {
+                serde_json::from_slice(key).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, format!("bad service account key: {}", e)))
+            }
+        }
+    }
+}

--- a/src/storage/cloud_storage/workflow_identity.rs
+++ b/src/storage/cloud_storage/workflow_identity.rs
@@ -1,0 +1,66 @@
+// TODO: Test whether on GCE
+// See https://github.com/mechiru/gcemeta/blob/master/src/metadata.rs
+// See https://github.com/mechiru/gouth/blob/master/gouth/src/source/metadata.rs
+
+use crate::storage::{Error, ErrorKind};
+use hyper::client::connect::dns::GaiResolver;
+use hyper::client::HttpConnector;
+use hyper::http::header;
+use hyper::{Body, Client, Method, Request, Response};
+use hyper_rustls::HttpsConnector;
+
+// Environment variable specifying the GCE metadata hostname.
+// If empty, the default value of `METADATA_IP` is used instead.
+// const METADATA_HOST_VAR: &str = "GCE_METADATA_HOST";
+
+// Documented metadata server IP address.
+// const METADATA_IP: &str = "169.254.169.254";
+
+// When is using the IP better?
+const METADATA_HOST: &str = "metadata.google.internal";
+
+// `github.com/bolcom/libunftp v{package_version}`
+const USER_AGENT: &str = concat!("github.com/bolcom/libunftp v", env!("CARGO_PKG_VERSION"));
+
+// TODO: MAP to useful error type
+// TODO: Cache the token.
+pub(super) async fn request_token(service: Option<String>, client: Client<HttpsConnector<HttpConnector<GaiResolver>>>) -> Result<TokenResponse, Error> {
+    // Does same as curl -s -HMetadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
+    let suffix = format!("instance/service-accounts/{}/token", service.unwrap_or_else(|| "default".to_string()));
+    //let host = env::var(METADATA_HOST_VAR).unwrap_or_else(|_| METADATA_IP.into());
+    let host = METADATA_HOST;
+    let uri = format!("http://{}/computeMetadata/v1/{}", host, suffix);
+
+    let request = Request::builder()
+        .uri(uri)
+        .header("Metadata-Flavor", "Google")
+        .header(header::USER_AGENT, USER_AGENT)
+        .method(Method::GET)
+        .body(Body::empty())
+        .map_err(|e| Error::new(ErrorKind::PermanentFileNotAvailable, e))?;
+
+    let response: Response<Body> = client.request(request).await.map_err(|e| Error::new(ErrorKind::PermanentFileNotAvailable, e))?;
+
+    let body_bytes = hyper::body::to_bytes(response.into_body())
+        .await
+        .map_err(|e| Error::new(ErrorKind::PermanentFileNotAvailable, e))?;
+
+    let unmarshall_result: serde_json::Result<TokenResponse> = serde_json::from_slice(body_bytes.to_vec().as_slice());
+    unmarshall_result.map_err(|e| Error::new(ErrorKind::PermanentFileNotAvailable, e))
+}
+
+// Example:
+// ```
+// {
+//   "access_token": "ya29.c.Ks0Cywchw6EJei_7ifQZKV....oRZy70M2ahRMfHY1qzUxGfxQcQ1cQ",
+//   "expires_in": 3166,
+//   "token_type": "Bearer"
+// }
+// ```
+//
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(super) struct TokenResponse {
+    pub(super) token_type: String,
+    pub(super) access_token: String,
+    pub(super) expires_in: u64,
+}


### PR DESCRIPTION
Implements a simple version of #298 (GKE Workload identity) that requests a token from the meta data sever on every GCS request. No caching at the momement.

This introduces a breaking change in the libunftp Cloud Storage API in that the `CloudStorage::new` method now takes a `Into<AuthMethod>` instead of a `yup_oauth2::ServiceAccountKey`