### PR TITLE
Handle path names that contain \r and/or \n according to rfc-2640

### DIFF
--- a/src/server/controlchan/line_parser/tests.rs
+++ b/src/server/controlchan/line_parser/tests.rs
@@ -345,6 +345,18 @@ fn parse_mkd_non_ascii() {
 }
 
 #[test]
+fn parse_mkd_spaces() {
+    let input = "MKD   12 3 \r\n";
+    assert_eq!(parse(input), Ok(Command::Mkd { path: "  12 3 ".into() }));
+}
+
+#[test]
+fn parse_mkd_cr() {
+    let input = "MKD foo\r\0\nboo.bar\r\n";
+    assert_eq!(parse(input), Ok(Command::Mkd { path: "foo\r\nboo.bar".into() }));
+}
+
+#[test]
 fn parse_allo() {
     let input = "ALLO\r\n";
     assert_eq!(parse(input), Ok(Command::Allo {}));


### PR DESCRIPTION
This is mentioned in RFC 2640:

> When a `CR` character is encountered as part of a pathname it MUST be
   padded with a `NUL` character prior to sending the command. On
   receipt of a pathname containing a `CR NUL` sequence the `NUL`
   character MUST be stripped away