### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.42"
 bytes = "1.0.1"
-bytes05 = { package="bytes", version= "0.5" }
 chrono = {version = "0.4.19", features = ["serde"]}
 derive_more = { version = "0.99.11", features = ["display"] }
 futures = {version = "0.3.12", features = ["std"]}
@@ -34,8 +33,8 @@ mime = {version = "0.3.16", optional = true}
 path_abs = "0.5.0"
 percent-encoding = { version = "2.1.0", optional = true }
 prometheus = "0.11.0"
-proxy-protocol = {version = "0.1.1"}
-rand = "0.8.1"
+proxy-protocol = {version = "0.2.0"}
+rand = "0.8.2"
 regex = "1.4.3"
 rustls = "0.19.0"
 serde = { version = "1.0.120", optional = true, features = ["derive"] }
@@ -43,16 +42,18 @@ serde_json = { version = "1.0.61", optional = true }
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_info"] }
 slog-stdlog = "4.1.0"
 thiserror = "1.0.23"
-tokio = { version = "1.0.1", features = ["rt", "net", "sync", "io-util", "macros", "time", "fs"]}
-tokio-stream = "0.1.1"
+tokio = { version = "1.0.2", features = ["rt", "net", "sync", "io-util", "macros", "time", "fs"]}
+tokio-stream = "0.1.2"
 tokio-rustls = { version = "0.22.0" }
-tokio-util = { version = "0.6.0", features=["codec", "compat"] }
+tokio-util = { version = "0.6.2", features=["codec", "compat"] }
 tracing = "0.1.22"
 tracing-attributes = "0.1.11"
 tracing-futures = { version = "0.2.4", features = ["std", "std-future", "futures-03"]}
 uuid = { version = "0.8.2", features = ["v4"] }
 yup-oauth2 = {version = "5.0.1", optional = true}
 
+[patch.crates-io]
+proxy-protocol = {git = "https://github.com/bolcom/proxy-protocol", branch = "nonius/upgrade-bytes"}
 
 [target.'cfg(unix)'.dependencies]
 pam-auth = { package = "pam", version = "0.7.0", optional = true }
@@ -61,7 +62,7 @@ pam-auth = { package = "pam", version = "0.7.0", optional = true }
 async_ftp = "5.0.0"
 clap = "2.33.3"
 slog-term = "2.6.0"
-slog-async = "2.5.0"
+slog-async = "2.6.0"
 pretty_assertions = "0.6.1"
 pretty_env_logger = "0.4.0"
 tempfile = "3.2.0"

--- a/src/server/proxy_protocol.rs
+++ b/src/server/proxy_protocol.rs
@@ -1,5 +1,6 @@
 use super::session::SharedSession;
 use crate::{auth::UserDetail, storage::StorageBackend};
+use bytes::Bytes;
 use lazy_static::lazy_static;
 use proxy_protocol::{version1::ProxyAddressFamily, ProxyHeader};
 use rand::{rngs::OsRng, RngCore};
@@ -68,7 +69,7 @@ async fn read_proxy_header(tcp_stream: &mut tokio::net::TcpStream) -> Result<Pro
                     return Err(ProxyError::CrlfError);
                 }
 
-                let mut phb = bytes05::Bytes::copy_from_slice(&rbuf[..=i + pos]);
+                let mut phb = Bytes::copy_from_slice(&rbuf[..=i + pos]);
                 let proxyhdr = match ProxyHeader::decode(&mut phb) {
                     Ok(h) => h,
                     Err(_) => return Err(ProxyError::DecodeError),


### PR DESCRIPTION
To be able upgrade bytes, proxy-protocol was patched from a fork.