### PR TITLE
Improved the STAT command

### DIFF
--- a/src/server/controlchan/commands/stat.rs
+++ b/src/server/controlchan/commands/stat.rs
@@ -56,8 +56,21 @@ where
     async fn handle(&self, args: CommandContext<Storage, User>) -> Result<Reply, ControlChanError> {
         match self.path.clone() {
             None => {
-                let text: Vec<&str> = vec!["Status:", "Powered by libunftp"];
-                // TODO: Add useful information here like libunftp version, auth type, storage type, IP etc.
+                let session = args.session.lock().await;
+                let text: Vec<String> = vec![
+                    "server status:".to_string(),
+                    format!("powered by libunftp: {}", env!("CARGO_PKG_VERSION")),
+                    format!("sbe: {}", session.storage.name()),
+                    format!("authenticator: {}", args.authenticator.name()),
+                    format!("user: {}", session.username.as_ref().unwrap()),
+                    format!("client addr: {}", session.source),
+                    format!("ftps configured: {}", args.tls_configured),
+                    format!("cmd channel in tls mode: {}", session.cmd_tls),
+                    format!("data channel in tls mode: {}", session.data_tls),
+                    format!("cwd: {}", session.cwd.to_string_lossy()),
+                    format!("rename from path: {:?}", session.rename_from),
+                    format!("offset for REST: {}", session.start_pos),
+                ];
                 Ok(Reply::new_multiline(ReplyCode::SystemStatus, text))
             }
             Some(path) => {

--- a/src/storage/storage_backend.rs
+++ b/src/storage/storage_backend.rs
@@ -143,6 +143,11 @@ pub trait StorageBackend<U: Sync + Send + Debug>: Send + Sync + Debug {
     /// The concrete type of the _metadata_ used by this storage backend.
     type Metadata: Metadata + Sync + Send;
 
+    /// Implement to set the name of the storage back-end. By default it returns the type signature.
+    fn name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+
     /// Tells which optional features are supported by the storage back-end
     /// Return a value with bits set according to the FEATURE_* constants.
     fn supported_features(&self) -> u32 {


### PR DESCRIPTION
Getting stat more in line with the spec:


>STATUS (STAT)

>This command shall cause a status response to be sent over the control connection in the form of a reply. The command may be sent during a file transfer (along with the Telnet IP and Synch signals--see the Section on FTP Commands) in which case the server will respond with the status of the operation in progress, or it may be sent between file transfers. In the latter case, the command may have an argument field. If the argument is a pathname, the command is analogous to the "list" command except that data shall be transferred over the control connection. If a partial pathname is given, the server may respond with a list of file names or attributes associated with that specification. If no argument is given, the server should return general status information about the server FTP process. This should include current values of all transfer parameters and the status of connections.

Example response:

```txt
stat
211-Status:
Powered by libunftp: 0.16.0
sbe: unftp::storage::StorageBE
authenticator: unftp::user::LookupAuthenticator
user: anonymous
client addr: 127.0.0.1:51613
ftps configured: true
cmd channel in tls mode: true
211 data channel in tls mode: true
```