### PR TITLE
Allow PROT and PBSZ without requiring auth

### DIFF
--- a/src/server/controlchan/auth.rs
+++ b/src/server/controlchan/auth.rs
@@ -38,6 +38,8 @@ where
             | Event::Command(Command::User { .. })
             | Event::Command(Command::Pass { .. })
             | Event::Command(Command::Auth { .. })
+            | Event::Command(Command::Prot { .. })
+            | Event::Command(Command::Pbsz { .. })
             | Event::Command(Command::Feat)
             | Event::Command(Command::Noop)
             | Event::Command(Command::Quit) => self.next.handle(event).await,

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -60,7 +60,7 @@ pub enum ErrorKind {
     /// Error that will cause a FTP reply code of 451 to be returned to the FTP client. Its means
     /// the requested action was aborted due to a local error (internal storage back-end error) in
     /// processing.
-    /// #[display(fmt = "451 Local error")]
+    #[display(fmt = "451 Local error")]
     LocalError,
     /// 551 Requested action aborted. Page type unknown.
     #[display(fmt = "551 Page type unknown")]


### PR DESCRIPTION
This fixes an issue logged in PR #327 where the PHP FTP client issues the
PROT and PBSZ commands to switch the data channel to FTPS but does it
before authenticating. The current libunftp behaviour is to prevent PROT
and PBSZ for unauthenticated clients. This PR then allows it. We might
want to make it a setting though in a PR after this?

Closes #327