### PR TITLE
Load TLS certs only once

### DIFF
--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -7,7 +7,6 @@ use super::{
 use crate::server::session::SharedSession;
 use crate::{
     auth::UserDetail,
-    server::tls::new_config,
     storage::{Error, ErrorKind, Metadata, StorageBackend},
 };
 
@@ -223,9 +222,10 @@ where
     async fn writer(socket: tokio::net::TcpStream, ftps_mode: FtpsConfig) -> Box<dyn tokio::io::AsyncWrite + Send + Unpin + Sync> {
         match ftps_mode {
             FtpsConfig::Off => Box::new(socket) as Box<dyn tokio::io::AsyncWrite + Send + Unpin + Sync>,
-            FtpsConfig::On { certs_file, key_file } => {
+            FtpsConfig::Building { .. } => panic!("Illegal state"),
+            FtpsConfig::On { tls_config } => {
                 let io = async move {
-                    let acceptor: TlsAcceptor = new_config(certs_file, key_file).into();
+                    let acceptor: TlsAcceptor = tls_config.into();
                     acceptor.accept(socket).await.unwrap()
                 }
                 .await;
@@ -238,9 +238,10 @@ where
     async fn reader(socket: tokio::net::TcpStream, ftps_mode: FtpsConfig) -> Box<dyn tokio::io::AsyncRead + Send + Unpin + Sync> {
         match ftps_mode {
             FtpsConfig::Off => Box::new(socket) as Box<dyn tokio::io::AsyncRead + Send + Unpin + Sync>,
-            FtpsConfig::On { certs_file, key_file } => {
+            FtpsConfig::Building { .. } => panic!("Illegal state"),
+            FtpsConfig::On { tls_config } => {
                 let io = async move {
-                    let acceptor: TlsAcceptor = new_config(certs_file, key_file).into();
+                    let acceptor: TlsAcceptor = tls_config.into();
                     acceptor.accept(socket).await.unwrap()
                 }
                 .await;


### PR DESCRIPTION
Currently we setup the TLS server configuration on every connection, loading the certificate and key from its files every time.

Besides that this is wrong in the sense that this won't allow us to do TLS session resumption by way of a shared cache, this is also inefficient and according to [rustls](https://crates.io/crates/rustls) docs, constructing the [rustls::ServerConfig](https://docs.rs/rustls/0.19.1/rustls/struct.ServerConfig.html) object is expensive and should be done once per process.

I'm not completely happy with how I changed the `FtpsConfig` enum but that I can fix in another refactor.