### PR TITLE
Implement configurable TLS session resumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Upcoming
+
+- Fixed output formatting of the FEAT command.
+- Fixed the SIZE command that wrongly took the REST restart position into account and also caused number overflows 
+  because of that.
+- Removed panics that could happen when failing to load the TLS certificate or key, these errors are now propagated via 
+  the `Server::listen` method.
+- Implemented TLS session resumption with server side session IDs.
+- Implemented TLS session resumption with [tickets](https://tools.ietf.org/html/rfc5077).  
+- Added the `Server::ftps_tls_flags` method to allow switching TLS features on or off.
+
 ## 2021-04-18 libunftp v0.17.1
 
 _tag: libunftp-0.17.1_

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,14 @@ members = [
 
 [dependencies]
 async-trait = "0.1.42"
+bitflags = "1.2.1"
 bytes = "1.0.1"
 chrono = {version = "0.4.19", features = ["serde"]}
 derive_more = { version = "0.99.11", features = ["display"] }
 futures = {version = "0.3.12", features = ["std"]}
 itertools = "0.10.0"
 lazy_static = "1.4.0"
+moka = "0.3.0"
 prometheus = "0.12.0"
 proxy-protocol = "0.3.0"
 rand = "0.8.3"

--- a/src/server/ftpserver/options.rs
+++ b/src/server/ftpserver/options.rs
@@ -1,5 +1,6 @@
 //! Contains code pertaining to the setup options that can be given to the [`Server`](crate::Server)
 
+use bitflags::bitflags;
 use std::fmt::Formatter;
 use std::ops::Range;
 use std::{
@@ -53,7 +54,7 @@ impl From<&str> for PassiveHost {
     }
 }
 
-/// The option to `Server.ftps_required`. It allows the user to specify whethere clients are required
+/// The option to `Server.ftps_required`. It allows the user to specify whether clients are required
 /// to upgrade a to secure TLS connection i.e. use FTPS.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum FtpsRequired {
@@ -87,5 +88,27 @@ impl Display for FtpsRequired {
                 FtpsRequired::None => "FTPS not enforced",
             }
         )
+    }
+}
+
+bitflags! {
+    /// Used to configure TLS options employed for FTPS
+    pub struct TlsFlags: u32 {
+        /// Enables TLS version 1.2
+        const V1_2               = 0b00000001;
+        /// Enables TLS version 1.3
+        const V1_3               = 0b00000010;
+        /// Enables TLS session resumption via means of sever side session IDs.
+        const RESUMPTION_SESS_ID = 0b00001000;
+        /// Enables TLS session resumption via means tickets ([rfc5077](https://tools.ietf.org/html/rfc5077))
+        const RESUMPTION_TICKETS = 0b00010000;
+        /// Enables the latest safe TLS versions i.e. 1.2 and 1.3
+        const LATEST_VERSIONS = Self::V1_2.bits | Self::V1_3.bits;
+    }
+}
+
+impl Default for TlsFlags {
+    fn default() -> TlsFlags {
+        TlsFlags::V1_2 | TlsFlags::RESUMPTION_SESS_ID | TlsFlags::RESUMPTION_TICKETS
     }
 }

--- a/src/server/tls.rs
+++ b/src/server/tls.rs
@@ -1,5 +1,5 @@
-use rustls::{internal::pemfile, Certificate, KeyLogFile, NoClientAuth, NoServerSessionStorage, PrivateKey, ServerConfig};
-use std::convert::TryFrom;
+use crate::options::TlsFlags;
+use rustls::{internal::pemfile, Certificate, NoClientAuth, NoServerSessionStorage, PrivateKey, ProtocolVersion, ServerConfig, Ticketer};
 use std::error::Error;
 use std::fmt;
 use std::fmt::Formatter;
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 // FTPSConfig shows how TLS security is configured for the server or a particular channel.
 #[derive(Clone)]
@@ -37,62 +38,103 @@ impl fmt::Display for FtpsNotAvailable {
 
 impl Error for FtpsNotAvailable {}
 
-// Attempts to convert TLS configuration to an TLS Acceptor
-impl TryFrom<FtpsConfig> for tokio_rustls::TlsAcceptor {
-    type Error = FtpsNotAvailable;
-
-    fn try_from(config: FtpsConfig) -> Result<Self, Self::Error> {
-        match config {
-            FtpsConfig::Off => Err(FtpsNotAvailable),
-            FtpsConfig::Building { certs_file, key_file } => {
-                let acceptor: tokio_rustls::TlsAcceptor = new_config(certs_file, key_file).map_err(|_e| FtpsNotAvailable)?.into();
-                Ok(acceptor)
-            }
-            FtpsConfig::On { tls_config } => {
-                let acceptor: tokio_rustls::TlsAcceptor = tls_config.into();
-                Ok(acceptor)
-            }
-        }
-    }
-}
-
-pub fn new_config<P: AsRef<Path>>(certs_file: P, key_file: P) -> std::io::Result<Arc<ServerConfig>> {
+pub fn new_config<P: AsRef<Path>>(certs_file: P, key_file: P, flags: TlsFlags) -> std::io::Result<Arc<ServerConfig>> {
     let certs: Vec<Certificate> = load_certs(certs_file)?;
     let privkey: PrivateKey = load_private_key(key_file)?;
 
-    let mut config = ServerConfig::new(NoClientAuth::new());
-    config.session_storage = Arc::new(NoServerSessionStorage {});
-    config.key_log = Arc::new(KeyLogFile::new());
-    config.set_single_cert(certs, privkey).expect("Failed to setup TLS certificate chain and key");
+    let mut config = rustls::ServerConfig::new(NoClientAuth::new());
+    // Support session resumption with server side state (Session IDs)
+    config.session_storage = if flags.contains(TlsFlags::RESUMPTION_SESS_ID) {
+        TlsSessionCache::new(1024)
+    } else {
+        Arc::new(NoServerSessionStorage {})
+    };
+    // Support session resumption with tickets. See https://tools.ietf.org/html/rfc5077
+    if flags.contains(TlsFlags::RESUMPTION_TICKETS) {
+        config.ticketer = Ticketer::new();
+    };
+    // Don't allow dumping session keys
+    config.key_log = Arc::new(rustls::NoKeyLog {});
+    // No SNI, single certificate
+    config
+        .set_single_cert(certs, privkey)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    let mut versions: Vec<ProtocolVersion> = vec![];
+    if flags.contains(TlsFlags::V1_2) {
+        versions.push(ProtocolVersion::TLSv1_2)
+    }
+    if flags.contains(TlsFlags::V1_3) {
+        versions.push(ProtocolVersion::TLSv1_3)
+    }
+    config.versions = versions;
+
     Ok(Arc::new(config))
 }
 
 fn load_certs<P: AsRef<Path>>(filename: P) -> std::io::Result<Vec<Certificate>> {
     let certfile: File = File::open(filename)?;
     let mut reader: BufReader<File> = BufReader::new(certfile);
-    Ok(pemfile::certs(&mut reader).unwrap())
+    pemfile::certs(&mut reader).map_err(|_| std::io::Error::from(std::io::ErrorKind::Other))
 }
 
 fn load_private_key<P: AsRef<Path>>(filename: P) -> std::io::Result<PrivateKey> {
     let rsa_keys = {
         let keyfile = File::open(&filename)?;
         let mut reader = BufReader::new(keyfile);
-        pemfile::rsa_private_keys(&mut reader).expect("file contains invalid rsa private key")
+        pemfile::rsa_private_keys(&mut reader).map_err(|_| std::io::Error::from(std::io::ErrorKind::Other))?
     };
 
     let pkcs8_keys = {
-        let keyfile = File::open(&filename).expect("cannot open private key file");
+        let keyfile = File::open(&filename)?;
         let mut reader = BufReader::new(keyfile);
-        pemfile::pkcs8_private_keys(&mut reader).expect("file contains invalid pkcs8 private key (encrypted keys not supported)")
+        pemfile::pkcs8_private_keys(&mut reader).map_err(|_| std::io::Error::from(std::io::ErrorKind::Other))?
     };
 
     // prefer to load pkcs8 keys
     let key = if !pkcs8_keys.is_empty() {
         pkcs8_keys[0].clone()
     } else {
-        assert!(!rsa_keys.is_empty());
+        if rsa_keys.is_empty() {
+            return Err(std::io::Error::from(std::io::ErrorKind::Other));
+        }
         rsa_keys[0].clone()
     };
 
-    return Ok(key);
+    Ok(key)
+}
+
+/// Stores the session IDs server side.
+struct TlsSessionCache {
+    cache: moka::sync::Cache<Vec<u8>, Vec<u8>>,
+}
+
+impl TlsSessionCache {
+    /// Make a new TlsSessionCache.  `size` is the maximum
+    /// number of stored sessions.
+    pub fn new(size: usize) -> Arc<TlsSessionCache> {
+        debug_assert!(size > 0);
+        Arc::new(TlsSessionCache {
+            cache: moka::sync::CacheBuilder::new(size).time_to_idle(Duration::from_secs(5 * 60)).build(),
+        })
+    }
+}
+
+impl rustls::StoresServerSessions for TlsSessionCache {
+    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
+        self.cache.insert(key, value);
+        true
+    }
+
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        self.cache.get(&key.to_vec())
+    }
+
+    fn take(&self, key: &[u8]) -> Option<Vec<u8>> {
+        let key_as_vec = key.to_vec();
+        self.cache.get(&key_as_vec)
+        // For some reason rustls always calls take and so removes the session ID which then breaks
+        // FileZilla for instance. So I implement take here to not really take, only get...
+        // self.cache.invalidate(&key_as_vec);
+    }
 }


### PR DESCRIPTION
Previously TLS session resumption was disabled because it broke the lftp
client. This re-enables it.