### PR TITLE
Add TLS Client Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Upcoming
+
+- Added Mutual TLS support.
+
 ## 2021-04-25 libunftp v0.17.2
 
 _tag: libunftp-0.17.2_

--- a/crates/unftp-sbe-gcs/src/response_body.rs
+++ b/crates/unftp-sbe-gcs/src/response_body.rs
@@ -69,7 +69,7 @@ impl Item {
         let path: PathBuf = PathBuf::from(self.name.clone());
         let metadata: ObjectMetadata = self.to_metadata()?;
 
-        Ok(Fileinfo { metadata, path })
+        Ok(Fileinfo { path, metadata })
     }
 }
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -3,9 +3,9 @@
 //! Contains the [`Authenticator`](crate::auth::Authenticator) and [`UserDetail`](crate::auth::UserDetail)
 //! traits that are used to extend libunftp's authentication and user detail storage capabilities.
 //!
-//! Pre-made implemenations exists on crates.io and you can define your own implementation to
-//! integrate your FTP(S) server with whatever authentication mechanism you need. For example, to
-//! define an `Authenticator` that will randomly decide:
+//! Pre-made implemenations exists on crates.io (search for `unftp-auth-`) and you can define your
+//! own implementation to integrate your FTP(S) server with whatever authentication mechanism you
+//! need. For example, to define an `Authenticator` that will randomly decide:
 //!
 //! 1. Declare a dependency on the async-trait crate
 //!

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,7 +1,10 @@
-//! Contains the [`StorageBackend`](crate::storage::StorageBackend) trait and its bundled implementations that can used by the `Server`.
+//! Contains the [`StorageBackend`](crate::storage::StorageBackend) trait that can be implemented to
+//! create virtual file systems for libunftp.
 //!
-//! You can define your own implementation to integrate your FTP(S) server with whatever
-//! backend you need. To create a new storage back-end:
+//! Pre-made implemenations exists on crates.io (search for `unftp-sbe-`) and you can define your
+//! own implementation to integrate your FTP(S) server with whatever storage mechanism you prefer.
+//!
+//! To create a new storage back-end:
 //!
 //! 1. Declare a dependency on the async-trait crate
 //!


### PR DESCRIPTION
This PR adds support for Mutual TLS / client certificate validation. Currently there is no ability for custom checks on the certificate but may be added in the future.