### PR TITLE
Implement per user IP allow lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Upcoming
+
+- Authenticators can now also take the connection source IP and the client certificate chain in account in addition to 
+  the password when performing authentication.
+- **Breaking**: The `Authenticator::authenticate` method now takes a `Credentials` structure instead of a `str` reference for the 
+  second parameter.
+- **unftp-auth-jsonfile**: Supports per user IP allow ranges
 
 ## 2021-05-22 unftp-sbe-gcs v0.1.1
 

--- a/crates/unftp-auth-jsonfile/Cargo.toml
+++ b/crates/unftp-auth-jsonfile/Cargo.toml
@@ -30,6 +30,8 @@ ring = "0.16.20"
 base64 = "0.13.0"
 bytes = "1.0.1"
 valid = "0.3.1"
+iprange = "0.6.4"
+ipnet = "2.3.0"
 
 [dev-dependencies]
 pretty_env_logger = "0.4.0"

--- a/crates/unftp-auth-rest/src/lib.rs
+++ b/crates/unftp-auth-rest/src/lib.rs
@@ -8,7 +8,7 @@
 
 use async_trait::async_trait;
 use hyper::{http::uri::InvalidUri, Body, Client, Method, Request};
-use libunftp::auth::{AuthenticationError, Authenticator, DefaultUser};
+use libunftp::auth::{AuthenticationError, Authenticator, Credentials, DefaultUser};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use regex::Regex;
 use serde_json::{json, Value};
@@ -119,8 +119,9 @@ impl RestAuthenticator {
 impl Authenticator<DefaultUser> for RestAuthenticator {
     #[allow(clippy::type_complexity)]
     #[tracing_attributes::instrument]
-    async fn authenticate(&self, username: &str, password: &str) -> Result<DefaultUser, AuthenticationError> {
+    async fn authenticate(&self, username: &str, creds: &Credentials) -> Result<DefaultUser, AuthenticationError> {
         let username_url = utf8_percent_encode(username, NON_ALPHANUMERIC).collect::<String>();
+        let password = creds.password.as_ref().ok_or(AuthenticationError::BadPassword)?.as_ref();
         let password_url = utf8_percent_encode(password, NON_ALPHANUMERIC).collect::<String>();
         let url = self.fill_encoded_placeholders(&self.url, &username_url, &password_url);
 

--- a/src/auth/anonymous.rs
+++ b/src/auth/anonymous.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 /// use async_trait::async_trait;
 ///
 /// let my_auth = AnonymousAuthenticator{};
-/// assert_eq!(futures::executor::block_on(my_auth.authenticate("Finn", "I ❤️ PB")).unwrap(), DefaultUser{});
+/// assert_eq!(futures::executor::block_on(my_auth.authenticate("Finn", &"I ❤️ PB".into())).unwrap(), DefaultUser{});
 /// ```
 ///
 #[derive(Debug)]
@@ -24,7 +24,7 @@ pub struct AnonymousAuthenticator;
 impl Authenticator<DefaultUser> for AnonymousAuthenticator {
     #[allow(clippy::type_complexity)]
     #[tracing_attributes::instrument]
-    async fn authenticate(&self, _username: &str, _password: &str) -> Result<DefaultUser, AuthenticationError> {
+    async fn authenticate(&self, _username: &str, _password: &Credentials) -> Result<DefaultUser, AuthenticationError> {
         Ok(DefaultUser {})
     }
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -16,7 +16,7 @@
 //! 2. Implement the [`Authenticator`] trait and optionally the [`UserDetail`] trait:
 //!
 //! ```no_run
-//! use libunftp::auth::{Authenticator, AuthenticationError, UserDetail};
+//! use libunftp::auth::{Authenticator, AuthenticationError, UserDetail, Credentials};
 //! use async_trait::async_trait;
 //! use unftp_sbe_fs::Filesystem;
 //!
@@ -25,7 +25,7 @@
 //!
 //! #[async_trait]
 //! impl Authenticator<RandomUser> for RandomAuthenticator {
-//!     async fn authenticate(&self, _username: &str, _password: &str) -> Result<RandomUser, AuthenticationError> {
+//!     async fn authenticate(&self, _username: &str, _creds: &Credentials) -> Result<RandomUser, AuthenticationError> {
 //!         Ok(RandomUser{})
 //!     }
 //! }
@@ -62,7 +62,7 @@ pub use anonymous::AnonymousAuthenticator;
 
 pub(crate) mod authenticator;
 #[allow(unused_imports)]
-pub use authenticator::{AuthenticationError, Authenticator};
+pub use authenticator::{AuthenticationError, Authenticator, Credentials};
 
 mod user;
 pub use user::{DefaultUser, UserDetail};

--- a/src/server/controlchan/commands/pass.rs
+++ b/src/server/controlchan/commands/pass.rs
@@ -68,8 +68,13 @@ where
                 // without this, the REST authenticator hangs when
                 // performing a http call through Hyper
                 let session2clone = args.session.clone();
+                let creds = crate::auth::Credentials {
+                    password: Some(pass),
+                    source_ip: session.source.ip(),
+                    certificate_chain: None,
+                };
                 tokio::spawn(async move {
-                    let msg = match auther.authenticate(&user, &pass).await {
+                    let msg = match auther.authenticate(&user, &creds).await {
                         Ok(user) => {
                             if user.account_enabled() {
                                 let mut session = session2clone.lock().await;


### PR DESCRIPTION
This PR allows libunftp authenticators to also consider the source IP when making authentication decisions. It then implements a basic allow list functionality in `unftp-auth-jsonfile`.

Furthermore it readies the authenticator interface to also check the client certificate chain.

This unfortunately introduces a breaking change in the Authenticator API.