### PR TITLE
Replace deprecated rust-crypto crate with md-5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,12 @@ derive_more = { version = "0.99.14", features = ["display"] }
 futures = {version = "0.3.15", features = ["std"]}
 itertools = "0.10.0"
 lazy_static = "1.4.0"
+md-5 = "0.9.1"
 moka = "0.3.0"
 prometheus = "0.12.0"
 proxy-protocol = "0.3.0"
 rand = "0.8.3"
 rustls = "0.19.1"
-rust-crypto = "^0.2"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_info"] }
 slog-stdlog = "4.1.0"
 thiserror = "1.0.25"

--- a/src/server/controlchan/commands/mod.rs
+++ b/src/server/controlchan/commands/mod.rs
@@ -43,6 +43,7 @@ mod syst;
 mod type_;
 mod user;
 
+pub use self::md5::Md5;
 pub use abor::Abor;
 pub use acct::Acct;
 pub use allo::Allo;
@@ -54,7 +55,6 @@ pub use dele::Dele;
 pub use feat::Feat;
 pub use help::Help;
 pub use list::List;
-pub use md5::Md5;
 pub use mdtm::Mdtm;
 pub use mkd::Mkd;
 pub use mode::{Mode, ModeParam};

--- a/src/storage/storage_backend.rs
+++ b/src/storage/storage_backend.rs
@@ -4,8 +4,8 @@ use super::error::Error;
 use crate::storage::ErrorKind;
 use async_trait::async_trait;
 use chrono::prelude::{DateTime, Utc};
-use crypto::{digest::Digest, md5::Md5};
 use itertools::Itertools;
+use md5::{Digest, Md5};
 use std::{
     fmt::{self, Debug, Formatter, Write},
     path::Path,
@@ -187,10 +187,10 @@ pub trait StorageBackend<U: Sync + Send + Debug>: Send + Sync + Debug {
             if n == 0 {
                 break;
             }
-            md5sum.input(&buffer[0..n]);
+            md5sum.update(&buffer[0..n]);
         }
 
-        Ok(md5sum.result_str())
+        Ok(format!("{:x}", md5sum.finalize()))
     }
 
     /// Returns the list of files in the given directory.


### PR DESCRIPTION
This replaces the deprecated [rust-crypto](https://crates.io/crates/rust-crypto) crate (see [RUSTSEC-2016-0005](https://rustsec.org/advisories/RUSTSEC-2016-0005.html)) with the [md-5](https://crates.io/crates/md-5) crate.