### PR TITLE
Prevent easy user enumeration in unftp-auth-jsonfile

### DIFF
--- a/crates/unftp-auth-jsonfile/src/lib.rs
+++ b/crates/unftp-auth-jsonfile/src/lib.rs
@@ -247,9 +247,12 @@ impl Authenticator<DefaultUser> for JsonFileAuthenticator {
         } else {
             Err(AuthenticationError::BadUser)
         };
-        if res.is_err() {
-            sleep(Duration::from_millis(1500)).await;
-        }
+
+        match res {
+            Ok(_) | Err(AuthenticationError::BadUser) => {}
+            _ => sleep(Duration::from_millis(1500)).await,
+        };
+
         res
     }
 }


### PR DESCRIPTION
In PR #356  I degraded the security of the JSON Authenticator by sleeping if a user name was bad and not if it was good. This would allow hackers to enumerate users and get needed feedback and what user names are good.

This PR fixes that.