### PR TITLE
Polish and fix sub-crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ more flexible than traditional FTP servers and a perfect match for the cloud.
 It runs on top of the [Tokio](https://tokio.rs) asynchronous run-time and tries to make use of Async IO as much as 
 possible.
 
+Feature highlights:
+
+* 39 Supported FTP commands (see [commands directory](./src/server/controlchan/commands)) and growing
+* Ability to implement own storage back-ends
+* Ability to implement own authentication back-ends
+* Explicit FTPS (TLS)
+* Mutual TLS (Client certificates)
+* TLS session resumption
+* Prometheus integration
+* Structured Logging
+* [Proxy Protocol](https://www.haproxy.com/blog/haproxy/proxy-protocol/) support
+* Automatic session timeouts
+* Per user IP allow lists
+
+Known storage back-ends:
+
+* [unftp-sbe-fs](https://crates.io/crates/unftp-sbe-fs) - Stores files on the local filesystem 
+* [unftp-sbe-gcs](https://crates.io/crates/unftp-sbe-gcs) - Stores files in Google Cloud Storage
+
+Known authentication back-ends:
+
+* [unftp-auth-jsonfile](https://crates.io/crates/unftp-auth-jsonfile) - Authenticates against JSON text.
+* [unftp-auth-pam](https://crates.io/crates/unftp-auth-pam) - Authenticates via [PAM](https://en.wikipedia.org/wiki/Linux_PAM).
+* [unftp-auth-rest](https://crates.io/crates/unftp-auth-rest) - Consumes an HTTP API to authenticate.
+
 ## Prerequisites
 
 You'll need [Rust](https://rust-lang.org) 1.41 or higher to build libunftp.
@@ -73,6 +98,7 @@ For more help refer to:
 - the [examples](./examples) directory.
 - the [API Documentation](https://docs.rs/libunftp).
 - [unFTP server](https://github.com/bolcom/unFTP), a server from the bol.com techlab that is built on top of libunftp.
+- this [blog post](https://blog.abstractinvoke.com/05-07-unftp.html) about libunftp and unFTP.
 
 ## Getting help and staying informed
 

--- a/crates/unftp-auth-jsonfile/Cargo.toml
+++ b/crates/unftp-auth-jsonfile/Cargo.toml
@@ -19,19 +19,20 @@ readme = "README.md"
 
 [dependencies]
 async-trait = "0.1.50"
+base64 = "0.13.0"
+bytes = "1.0.1"
+ipnet = "2.3.0"
+iprange = "0.6.4"
 libunftp = { version="0.17.4", path="../../"}
-unftp-sbe-fs = { version="0.1", path="../unftp-sbe-fs"}
+ring = "0.16.20"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = { version = "1.0.64" }
 tokio = { version = "1.5.0", features = ["rt", "time"]}
 tracing = "0.1.25"
 tracing-attributes = "0.1.15"
-ring = "0.16.20"
-base64 = "0.13.0"
-bytes = "1.0.1"
+unftp-sbe-fs = { version="0.1", path="../unftp-sbe-fs"}
 valid = "0.3.1"
-iprange = "0.6.4"
-ipnet = "2.3.0"
 
 [dev-dependencies]
 pretty_env_logger = "0.4.0"
+tokio = { version = "1.5.0", features = ["macros"]}

--- a/crates/unftp-auth-jsonfile/README.md
+++ b/crates/unftp-auth-jsonfile/README.md
@@ -1,5 +1,10 @@
 # unftp-auth-jsonfile
 
+[![Crate Version](https://img.shields.io/crates/v/unftp-auth-jsonfile.svg)](https://crates.io/crates/unftp-auth-jsonfile)
+[![API Docs](https://docs.rs/unftp-auth-jsonfile/badge.svg)](https://docs.rs/unftp-auth-jsonfile)
+[![Crate License](https://img.shields.io/crates/l/unftp-auth-jsonfile.svg)](https://crates.io/crates/unftp-auth-jsonfile)
+[![Follow on Telegram](https://img.shields.io/badge/Follow%20on-Telegram-brightgreen.svg)](https://t.me/unftp)
+
 An authenticator back-end for [libunftp](https://github.com/bolcom/libunftp) that authenticates against a JSON file.
 
 ## License

--- a/crates/unftp-auth-pam/Cargo.toml
+++ b/crates/unftp-auth-pam/Cargo.toml
@@ -26,3 +26,6 @@ tracing-attributes = "0.1.15"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 pam-auth = { package = "pam", version = "0.7.0"}
+
+[dev-dependencies]
+tokio = { version = "1.5.0", features = ["macros"]}

--- a/crates/unftp-auth-pam/README.md
+++ b/crates/unftp-auth-pam/README.md
@@ -1,5 +1,10 @@
 # unftp-auth-pam
 
+[![Crate Version](https://img.shields.io/crates/v/unftp-auth-pam.svg)](https://crates.io/crates/unftp-auth-pam)
+[![API Docs](https://docs.rs/unftp-auth-pam/badge.svg)](https://docs.rs/unftp-auth-pam)
+[![Crate License](https://img.shields.io/crates/l/unftp-auth-pam.svg)](https://crates.io/crates/unftp-auth-pam)
+[![Follow on Telegram](https://img.shields.io/badge/Follow%20on-Telegram-brightgreen.svg)](https://t.me/unftp)
+
 An authenticator back-end for [libunftp](https://github.com/bolcom/libunftp) that authenticates against 
 [PAM](https://en.wikipedia.org/wiki/Pluggable_authentication_module).
 

--- a/crates/unftp-auth-rest/Cargo.toml
+++ b/crates/unftp-auth-rest/Cargo.toml
@@ -22,7 +22,6 @@ async-trait = "0.1.50"
 hyper = { version = "0.14.7", features= ["client", "runtime", "stream", "http1"]}
 hyper-rustls = { version = "0.22.1"}
 libunftp = { version="0.17.4", path="../../"}
-unftp-sbe-fs = { version="0.1", path="../unftp-sbe-fs"}
 percent-encoding = { version = "2.1.0"}
 regex = "1.4.6"
 serde = { version = "1.0.125", features = ["derive"] }
@@ -30,7 +29,9 @@ serde_json = { version = "1.0.64"}
 tokio = { version = "1.5.0", features = ["rt", "net", "sync", "io-util", "time"] }
 tracing = "0.1.25"
 tracing-attributes = "0.1.15"
+unftp-sbe-fs = { version="0.1", path="../unftp-sbe-fs"}
 
 
 [dev-dependencies]
 pretty_env_logger = "0.4.0"
+tokio = { version = "1.5.0", features = ["macros"] }

--- a/crates/unftp-auth-rest/README.md
+++ b/crates/unftp-auth-rest/README.md
@@ -1,5 +1,10 @@
 # unftp-auth-rest
 
+[![Crate Version](https://img.shields.io/crates/v/unftp-auth-rest.svg)](https://crates.io/crates/unftp-auth-rest)
+[![API Docs](https://docs.rs/unftp-auth-rest/badge.svg)](https://docs.rs/unftp-auth-rest)
+[![Crate License](https://img.shields.io/crates/l/unftp-auth-rest.svg)](https://crates.io/crates/unftp-auth-rest)
+[![Follow on Telegram](https://img.shields.io/badge/Follow%20on-Telegram-brightgreen.svg)](https://t.me/unftp)
+
 An authenticator back-end for [libunftp](https://github.com/bolcom/libunftp) that consumes an HTTP API to 
 authenticate. Please refer to the documentation and the examples directory for usage instructions.
 

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -20,23 +20,23 @@ readme = "README.md"
 
 [dependencies]
 async-trait = "0.1.50"
+futures = {version = "0.3.14", features = ["std"]}
 libunftp = { version="0.17.4", path="../../"}
-tracing = "0.1.25"
-tracing-attributes = "0.1.15"
+path_abs = "0.5.0"
 tokio = { version = "1.5.0", features = ["rt", "net", "sync", "io-util", "time", "fs"] }
 tokio-stream = "0.1.5"
-futures = {version = "0.3.14", features = ["std"]}
-path_abs = "0.5.0"
+tracing = "0.1.25"
+tracing-attributes = "0.1.15"
 
 [dev-dependencies]
 async_ftp = "5.0.0"
 clap = "2.33.3"
-slog-term = "2.8.0"
-slog-async = "2.6.0"
+more-asserts = "0.2.1"
 pretty_assertions = "0.7.1"
+pretty_env_logger = "0.4.0"
+rand = "0.8.3"
+slog-async = "2.6.0"
+slog-term = "2.8.0"
 tempfile = "3.2.0"
 tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread"]}
 tracing-subscriber = "0.2.15"
-more-asserts = "0.2.1"
-pretty_env_logger = "0.4.0"
-rand = "0.8.3"

--- a/crates/unftp-sbe-gcs/Cargo.toml
+++ b/crates/unftp-sbe-gcs/Cargo.toml
@@ -19,6 +19,7 @@ readme = "README.md"
 
 [dependencies]
 async-trait = "0.1.50"
+base64 = "0.13.0"
 bytes = "1.0.1"
 chrono = { version = "0.4.19", default-features = false, features = ["std"] }
 futures = {version = "0.3.14", features = ["std"]}
@@ -27,6 +28,8 @@ hyper-rustls = { version = "0.22.1"}
 libunftp = { version="0.17.4", path="../../"}
 mime = {version = "0.3.16"}
 percent-encoding = { version = "2.1.0"}
+serde = { version = "1.0.125", features = ["derive"] }
+serde_json = { version = "1.0.64"}
 tokio = { version = "1.5.0", features = ["rt", "net", "sync", "io-util", "time", "fs"] }
 tokio-stream = "0.1.5"
 tokio-util = { version = "0.6.6", features=["codec", "compat"] }
@@ -34,22 +37,19 @@ tracing = "0.1.25"
 tracing-attributes = "0.1.15"
 tracing-futures = { version = "0.2.5", features = ["std", "std-future", "futures-03"]}
 yup-oauth2 = {version = "5.0.3"}
-serde = { version = "1.0.125", features = ["derive"] }
-serde_json = { version = "1.0.64"}
-base64 = "0.13.0"
 
 [dev-dependencies]
 async_ftp = "5.0.0"
 clap = "2.33.3"
-slog-term = "2.8.0"
-slog-async = "2.6.0"
+lazy_static = "1.4.0"
+more-asserts = "0.2.1"
+path_abs = "0.5.0"
 pretty_assertions = "0.7.1"
 pretty_env_logger = "0.4.0"
+slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_info"] }
+slog-async = "2.6.0"
+slog-stdlog = "4.1.0"
+slog-term = "2.8.0"
 tempfile = "3.2.0"
 tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread"]}
 tracing-subscriber = "0.2.15"
-more-asserts = "0.2.1"
-lazy_static = "1.4.0"
-path_abs = "0.5.0"
-slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_info"] }
-slog-stdlog = "4.1.0"

--- a/crates/unftp-sbe-gcs/README.md
+++ b/crates/unftp-sbe-gcs/README.md
@@ -5,7 +5,6 @@
 [![Crate License](https://img.shields.io/crates/l/unftp-sbe-gcs.svg)](https://crates.io/crates/unftp-sbe-gcs)
 [![Follow on Telegram](https://img.shields.io/badge/Follow%20on-Telegram-brightgreen.svg)](https://t.me/unftp)
 
-
 An storage back-end for [libunftp](https://github.com/bolcom/libunftp) that let you store files in [Google Cloud Storage](https://cloud.google.com/storage). 
 Please refer to the documentation and the examples directory for usage instructions.
 


### PR DESCRIPTION
This PR:
1. Re-adds the tokio "macros" feature but this time to the dev-dependencies. Lack of this broke the documentation tests.
2. Sorts dependencies
3. Adds documentation about the JSON file authenticator's new allow list functionality.
4. Renames the 'ip_ranges' field to 'allowed_ip_ranges' field for the JSON format of unftp-auth-jsonfile.