### PR TITLE
Disable default prometheus features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ getrandom = "0.2"
 lazy_static = "1.4.0"
 md-5 = "0.9.1"
 moka = "0.3.0"
-prometheus = "0.12.0"
+prometheus = { version = "0.12.0", default-features = false }
 proxy-protocol = "0.3.0"
 rustls = "0.19.1"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_info"] }


### PR DESCRIPTION
The `prometheus` crate enables the `protobuf` feature by default, which is slow to compile and downstream users should be the ones to decide whether to enable it or not. This gives them the choice