### PR TITLE
Make user non-optional in storage back-ends

### DIFF
--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -21,6 +21,7 @@ mod ext;
 pub use ext::ServerExt;
 
 use async_trait::async_trait;
+use libunftp::auth::UserDetail;
 use libunftp::storage::{Error, ErrorKind, Fileinfo, Metadata, Result, StorageBackend};
 use std::{
     fmt::Debug,
@@ -89,7 +90,7 @@ impl Filesystem {
 }
 
 #[async_trait]
-impl<U: Send + Sync + Debug> StorageBackend<U> for Filesystem {
+impl<User: UserDetail> StorageBackend<User> for Filesystem {
     type Metadata = Meta;
 
     fn supported_features(&self) -> u32 {
@@ -97,7 +98,7 @@ impl<U: Send + Sync + Debug> StorageBackend<U> for Filesystem {
     }
 
     #[tracing_attributes::instrument]
-    async fn metadata<P: AsRef<Path> + Send + Debug>(&self, _user: &Option<U>, path: P) -> Result<Self::Metadata> {
+    async fn metadata<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<Self::Metadata> {
         let full_path = self.full_path(path).await?;
 
         let fs_meta = tokio::fs::symlink_metadata(full_path)
@@ -108,10 +109,10 @@ impl<U: Send + Sync + Debug> StorageBackend<U> for Filesystem {
 
     #[allow(clippy::type_complexity)]
     #[tracing_attributes::instrument]
-    async fn list<P>(&self, _user: &Option<U>, path: P) -> Result<Vec<Fileinfo<std::path::PathBuf, Self::Metadata>>>
+    async fn list<P>(&self, _user: &User, path: P) -> Result<Vec<Fileinfo<std::path::PathBuf, Self::Metadata>>>
     where
         P: AsRef<Path> + Send + Debug,
-        <Self as StorageBackend<U>>::Metadata: Metadata,
+        <Self as StorageBackend<User>>::Metadata: Metadata,
     {
         let full_path: PathBuf = self.full_path(path).await?;
 
@@ -134,12 +135,7 @@ impl<U: Send + Sync + Debug> StorageBackend<U> for Filesystem {
     }
 
     //#[tracing_attributes::instrument]
-    async fn get<P: AsRef<Path> + Send + Debug>(
-        &self,
-        _user: &Option<U>,
-        path: P,
-        start_pos: u64,
-    ) -> Result<Box<dyn tokio::io::AsyncRead + Send + Sync + Unpin>> {
+    async fn get<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P, start_pos: u64) -> Result<Box<dyn tokio::io::AsyncRead + Send + Sync + Unpin>> {
         use tokio::io::AsyncSeekExt;
 
         let full_path = self.full_path(path).await?;
@@ -153,7 +149,7 @@ impl<U: Send + Sync + Debug> StorageBackend<U> for Filesystem {
 
     async fn put<P: AsRef<Path> + Send, R: tokio::io::AsyncRead + Send + Sync + 'static + Unpin>(
         &self,
-        _user: &Option<U>,
+        _user: &User,
         bytes: R,
         path: P,
         start_pos: u64,
@@ -179,26 +175,26 @@ impl<U: Send + Sync + Debug> StorageBackend<U> for Filesystem {
     }
 
     #[tracing_attributes::instrument]
-    async fn del<P: AsRef<Path> + Send + Debug>(&self, _user: &Option<U>, path: P) -> Result<()> {
+    async fn del<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<()> {
         let full_path = self.full_path(path).await?;
         tokio::fs::remove_file(full_path).await.map_err(|error: std::io::Error| error.into())
     }
 
     #[tracing_attributes::instrument]
-    async fn rmd<P: AsRef<Path> + Send + Debug>(&self, _user: &Option<U>, path: P) -> Result<()> {
+    async fn rmd<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<()> {
         let full_path = self.full_path(path).await?;
         tokio::fs::remove_dir(full_path).await.map_err(|error: std::io::Error| error.into())
     }
 
     #[tracing_attributes::instrument]
-    async fn mkd<P: AsRef<Path> + Send + Debug>(&self, _user: &Option<U>, path: P) -> Result<()> {
+    async fn mkd<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<()> {
         tokio::fs::create_dir(self.full_path(path).await?)
             .await
             .map_err(|error: std::io::Error| error.into())
     }
 
     #[tracing_attributes::instrument]
-    async fn rename<P: AsRef<Path> + Send + Debug>(&self, _user: &Option<U>, from: P, to: P) -> Result<()> {
+    async fn rename<P: AsRef<Path> + Send + Debug>(&self, _user: &User, from: P, to: P) -> Result<()> {
         let from = self.full_path(from).await?;
         let to = self.full_path(to).await?;
 
@@ -222,7 +218,7 @@ impl<U: Send + Sync + Debug> StorageBackend<U> for Filesystem {
     }
 
     #[tracing_attributes::instrument]
-    async fn cwd<P: AsRef<Path> + Send + Debug>(&self, _user: &Option<U>, path: P) -> Result<()> {
+    async fn cwd<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<()> {
         let full_path = self.full_path(path).await?;
         tokio::fs::read_dir(full_path).await.map_err(|error: std::io::Error| error.into()).map(|_| ())
     }

--- a/crates/unftp-sbe-fs/src/tests.rs
+++ b/crates/unftp-sbe-fs/src/tests.rs
@@ -22,7 +22,7 @@ fn fs_stat() {
     // Since the filesystem backend is based on futures, we need a runtime to run it
     let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
     let filename = path.file_name().unwrap();
-    let my_meta = rt.block_on(fs.metadata(&Some(DefaultUser {}), filename)).unwrap();
+    let my_meta = rt.block_on(fs.metadata(&DefaultUser {}, filename)).unwrap();
 
     assert_eq!(meta.is_dir(), my_meta.is_dir());
     assert_eq!(meta.is_file(), my_meta.is_file());
@@ -46,7 +46,7 @@ fn fs_list() {
 
     // Since the filesystem backend is based on futures, we need a runtime to run it
     let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
-    let my_list = rt.block_on(fs.list(&Some(DefaultUser {}), "/")).unwrap();
+    let my_list = rt.block_on(fs.list(&DefaultUser {}, "/")).unwrap();
 
     assert_eq!(my_list.len(), 1);
 
@@ -71,7 +71,7 @@ fn fs_list_fmt() {
     let fs = Filesystem::new(&root.path());
 
     let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
-    let my_list = rt.block_on(fs.list_fmt(&Some(DefaultUser {}), "/")).unwrap();
+    let my_list = rt.block_on(fs.list_fmt(&DefaultUser {}, "/")).unwrap();
 
     let my_list = std::string::String::from_utf8(my_list.into_inner()).unwrap();
 
@@ -94,7 +94,7 @@ fn fs_get() {
 
     // Since the filesystem backend is based on futures, we need a runtime to run it
     let rt = Runtime::new().unwrap();
-    let mut my_file = rt.block_on(fs.get(&Some(DefaultUser {}), filename, 0)).unwrap();
+    let mut my_file = rt.block_on(fs.get(&DefaultUser {}, filename, 0)).unwrap();
     let mut my_content = Vec::new();
     rt.block_on(async move {
         let r = tokio::io::copy(&mut my_file, &mut my_content).await;
@@ -117,7 +117,7 @@ fn fs_put() {
     // to completion
     let rt = Runtime::new().unwrap();
 
-    rt.block_on(fs.put(&Some(DefaultUser {}), orig_content.as_ref(), "greeting.txt", 0))
+    rt.block_on(fs.put(&DefaultUser {}, orig_content.as_ref(), "greeting.txt", 0))
         .expect("Failed to `put` file");
 
     let mut written_content = Vec::new();
@@ -179,7 +179,7 @@ fn fs_mkd() {
     // to completion
     let rt = Runtime::new().unwrap();
 
-    rt.block_on(fs.mkd(&Some(DefaultUser {}), new_dir_name)).expect("Failed to mkd");
+    rt.block_on(fs.mkd(&DefaultUser {}, new_dir_name)).expect("Failed to mkd");
 
     let full_path = root.join(new_dir_name);
     let metadata = std::fs::symlink_metadata(full_path).unwrap();
@@ -198,7 +198,7 @@ fn fs_rename_file() {
     let rt = Runtime::new().unwrap();
 
     let fs = Filesystem::new(&root);
-    let r = rt.block_on(fs.rename(&Some(DefaultUser {}), &old_filename, &new_filename));
+    let r = rt.block_on(fs.rename(&DefaultUser {}, &old_filename, &new_filename));
     assert!(r.is_ok());
 
     let new_full_path = root.join(new_filename);
@@ -220,7 +220,7 @@ fn fs_rename_dir() {
     let rt = Runtime::new().unwrap();
 
     let fs = Filesystem::new(&root);
-    let r = rt.block_on(fs.rename(&Some(DefaultUser {}), &old_dir, &new_dir));
+    let r = rt.block_on(fs.rename(&DefaultUser {}, &old_dir, &new_dir));
     assert!(r.is_ok());
 
     let new_full_path = root.join(new_dir);
@@ -247,7 +247,7 @@ fn fs_md5() {
     // Since the filesystem backend is based on futures, we need a runtime to run it
     let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
 
-    let my_md5 = rt.block_on(fs.md5(&Some(DefaultUser {}), filename)).unwrap();
+    let my_md5 = rt.block_on(fs.md5(&DefaultUser {}, filename)).unwrap();
 
     assert_eq!("ced0b2edc3ec36e8d914320cb0268359", my_md5);
 }

--- a/src/auth/user.rs
+++ b/src/auth/user.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 /// - Account settings
 /// - Authorization information
 ///
-/// At this time, this trait doesn't contain much, but it will grow over time to allow for per-user
+/// At this time, this trait doesn't contain much, but it may grow over time to allow for per-user
 /// authorization and behaviour.
 pub trait UserDetail: Send + Sync + Display + Debug {
     /// Tells if this subject's account is enabled. This default implementation simply returns true.

--- a/src/server/controlchan/commands/cwd.rs
+++ b/src/server/controlchan/commands/cwd.rs
@@ -50,7 +50,7 @@ where
         let mut tx_fail = args.tx_control_chan.clone();
         let logger = args.logger;
 
-        if let Err(err) = storage.cwd(&session.user, path.clone()).await {
+        if let Err(err) = storage.cwd((*session.user).as_ref().unwrap(), path.clone()).await {
             slog::warn!(logger, "Failed to cwd directory: {}", err);
             let r = tx_fail.send(ControlChanMsg::StorageError(err)).await;
             if let Err(e) = r {

--- a/src/server/controlchan/commands/dele.rs
+++ b/src/server/controlchan/commands/dele.rs
@@ -49,7 +49,7 @@ where
         let mut tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
         let logger = args.logger;
         tokio::spawn(async move {
-            match storage.del(&user, path).await {
+            match storage.del((*user).as_ref().unwrap(), path).await {
                 Ok(_) => {
                     if let Err(err) = tx_success.send(ControlChanMsg::DelSuccess).await {
                         slog::warn!(logger, "{}", err);

--- a/src/server/controlchan/commands/md5.rs
+++ b/src/server/controlchan/commands/md5.rs
@@ -64,7 +64,7 @@ where
         }
 
         tokio::spawn(async move {
-            match storage.md5(&user, &path).await {
+            match storage.md5((*user).as_ref().unwrap(), &path).await {
                 Ok(md5) => {
                     if let Err(err) = tx_success
                         .send(ControlChanMsg::CommandChannelReply(Reply::new_with_string(

--- a/src/server/controlchan/commands/mdtm.rs
+++ b/src/server/controlchan/commands/mdtm.rs
@@ -46,7 +46,7 @@ where
         let logger = args.logger;
 
         tokio::spawn(async move {
-            match storage.metadata(&user, &path).await {
+            match storage.metadata((*user).as_ref().unwrap(), &path).await {
                 Ok(metadata) => {
                     let modification_time = match metadata.modified() {
                         Ok(v) => Some(v),

--- a/src/server/controlchan/commands/mkd.rs
+++ b/src/server/controlchan/commands/mkd.rs
@@ -49,7 +49,7 @@ where
         let mut tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
         let logger = args.logger;
         tokio::spawn(async move {
-            if let Err(err) = storage.mkd(&user, &path).await {
+            if let Err(err) = storage.mkd((*user).as_ref().unwrap(), &path).await {
                 if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(err)).await {
                     slog::warn!(logger, "{}", err);
                 }

--- a/src/server/controlchan/commands/rmd.rs
+++ b/src/server/controlchan/commands/rmd.rs
@@ -47,7 +47,7 @@ where
         let mut tx_success = args.tx_control_chan.clone();
         let mut tx_fail = args.tx_control_chan.clone();
         let logger = args.logger;
-        if let Err(err) = storage.rmd(&session.user, path).await {
+        if let Err(err) = storage.rmd((*session.user).as_ref().unwrap(), path).await {
             slog::warn!(logger, "Failed to delete directory: {}", err);
             let r = tx_fail.send(ControlChanMsg::StorageError(err)).await;
             if let Err(e) = r {

--- a/src/server/controlchan/commands/rnto.rs
+++ b/src/server/controlchan/commands/rnto.rs
@@ -38,7 +38,7 @@ where
         let reply = match session.rename_from.take() {
             Some(from) => {
                 let to = session.cwd.join(self.path.clone());
-                match storage.rename(&session.user, from, to).await {
+                match storage.rename((*session.user).as_ref().unwrap(), from, to).await {
                     Ok(_) => Reply::new(ReplyCode::FileActionOkay, "Renamed"),
                     Err(err) => {
                         slog::warn!(logger, "Error renaming: {:?}", err);

--- a/src/server/controlchan/commands/size.rs
+++ b/src/server/controlchan/commands/size.rs
@@ -43,7 +43,7 @@ where
         let logger = args.logger;
 
         tokio::spawn(async move {
-            match storage.metadata(&user, &path).await {
+            match storage.metadata((*user).as_ref().unwrap(), &path).await {
                 Ok(metadata) => {
                     let file_len = metadata.len();
                     if let Err(err) = tx_success

--- a/src/server/controlchan/commands/stat.rs
+++ b/src/server/controlchan/commands/stat.rs
@@ -86,7 +86,7 @@ where
                 let logger = args.logger;
 
                 tokio::spawn(async move {
-                    match storage.list_fmt(&user, path).await {
+                    match storage.list_fmt((*user).as_ref().unwrap(), path).await {
                         Ok(mut cursor) => {
                             let mut result: String = String::new();
                             match cursor.read_to_string(&mut result) {

--- a/src/server/controlchan/commands/user.rs
+++ b/src/server/controlchan/commands/user.rs
@@ -157,29 +157,24 @@ mod tests {
     impl StorageBackend<DefaultUser> for Vfs {
         type Metadata = Meta;
 
-        async fn metadata<P: AsRef<Path> + Send + Debug>(&self, user: &Option<DefaultUser>, path: P) -> Result<Self::Metadata> {
+        async fn metadata<P: AsRef<Path> + Send + Debug>(&self, user: &DefaultUser, path: P) -> Result<Self::Metadata> {
             todo!()
         }
 
-        async fn list<P: AsRef<Path> + Send + Debug>(&self, user: &Option<DefaultUser>, path: P) -> Result<Vec<Fileinfo<PathBuf, Self::Metadata>>>
+        async fn list<P: AsRef<Path> + Send + Debug>(&self, user: &DefaultUser, path: P) -> Result<Vec<Fileinfo<PathBuf, Self::Metadata>>>
         where
             <Self as StorageBackend<DefaultUser>>::Metadata: Metadata,
         {
             todo!()
         }
 
-        async fn get<P: AsRef<Path> + Send + Debug>(
-            &self,
-            user: &Option<DefaultUser>,
-            path: P,
-            start_pos: u64,
-        ) -> Result<Box<dyn AsyncRead + Send + Sync + Unpin>> {
+        async fn get<P: AsRef<Path> + Send + Debug>(&self, user: &DefaultUser, path: P, start_pos: u64) -> Result<Box<dyn AsyncRead + Send + Sync + Unpin>> {
             todo!()
         }
 
         async fn put<P: AsRef<Path> + Send + Debug, R: AsyncRead + Send + Sync + Unpin + 'static>(
             &self,
-            user: &Option<DefaultUser>,
+            user: &DefaultUser,
             input: R,
             path: P,
             start_pos: u64,
@@ -187,23 +182,23 @@ mod tests {
             todo!()
         }
 
-        async fn del<P: AsRef<Path> + Send + Debug>(&self, user: &Option<DefaultUser>, path: P) -> Result<()> {
+        async fn del<P: AsRef<Path> + Send + Debug>(&self, user: &DefaultUser, path: P) -> Result<()> {
             todo!()
         }
 
-        async fn mkd<P: AsRef<Path> + Send + Debug>(&self, user: &Option<DefaultUser>, path: P) -> Result<()> {
+        async fn mkd<P: AsRef<Path> + Send + Debug>(&self, user: &DefaultUser, path: P) -> Result<()> {
             todo!()
         }
 
-        async fn rename<P: AsRef<Path> + Send + Debug>(&self, user: &Option<DefaultUser>, from: P, to: P) -> Result<()> {
+        async fn rename<P: AsRef<Path> + Send + Debug>(&self, user: &DefaultUser, from: P, to: P) -> Result<()> {
             todo!()
         }
 
-        async fn rmd<P: AsRef<Path> + Send + Debug>(&self, user: &Option<DefaultUser>, path: P) -> Result<()> {
+        async fn rmd<P: AsRef<Path> + Send + Debug>(&self, user: &DefaultUser, path: P) -> Result<()> {
             todo!()
         }
 
-        async fn cwd<P: AsRef<Path> + Send + Debug>(&self, user: &Option<DefaultUser>, path: P) -> Result<()> {
+        async fn cwd<P: AsRef<Path> + Send + Debug>(&self, user: &DefaultUser, path: P) -> Result<()> {
             todo!()
         }
     }

--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -101,7 +101,7 @@ where
         let mut tx_sending: Sender<ControlChanMsg> = self.control_msg_tx.clone();
         let mut tx_error: Sender<ControlChanMsg> = self.control_msg_tx.clone();
         let mut output = Self::writer(self.socket, self.ftps_mode).await;
-        let get_result = self.storage.get_into(&self.user, path, self.start_pos, &mut output).await;
+        let get_result = self.storage.get_into((*self.user).as_ref().unwrap(), path, self.start_pos, &mut output).await;
         match get_result {
             Ok(bytes_copied) => {
                 if let Err(err) = output.shutdown().await {
@@ -127,7 +127,12 @@ where
         let mut tx_error = self.control_msg_tx.clone();
         let put_result = self
             .storage
-            .put(&self.user, Self::reader(self.socket, self.ftps_mode).await, path, self.start_pos)
+            .put(
+                (*self.user).as_ref().unwrap(),
+                Self::reader(self.socket, self.ftps_mode).await,
+                path,
+                self.start_pos,
+            )
             .await;
         match put_result {
             Ok(bytes) => {
@@ -157,7 +162,7 @@ where
         };
         let mut tx_ok = self.control_msg_tx.clone();
         let mut output = Self::writer(self.socket, self.ftps_mode).await;
-        let result = match self.storage.list_fmt(&self.user, path).await {
+        let result = match self.storage.list_fmt((*self.user).as_ref().unwrap(), path).await {
             Ok(cursor) => {
                 slog::debug!(self.logger, "Copying future for List");
                 let mut input = cursor;
@@ -195,7 +200,7 @@ where
         };
         let mut tx_ok = self.control_msg_tx.clone();
         let mut tx_error = self.control_msg_tx.clone();
-        match self.storage.nlst(&self.user, path).await {
+        match self.storage.nlst((*self.user).as_ref().unwrap(), path).await {
             Ok(mut input) => {
                 let mut output = Self::writer(self.socket, self.ftps_mode).await;
                 match tokio::io::copy(&mut input, &mut output).await {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -40,7 +40,7 @@
 //!
 //!     async fn metadata<P: AsRef<Path> + Send + Debug>(
 //!         &self,
-//!         user: &Option<DefaultUser>,
+//!         user: &DefaultUser,
 //!         path: P,
 //!     ) -> Result<Self::Metadata> {
 //!         unimplemented!()
@@ -48,7 +48,7 @@
 //!
 //!     async fn list<P: AsRef<Path> + Send + Debug>(
 //!         &self,
-//!         user: &Option<DefaultUser>,
+//!         user: &DefaultUser,
 //!         path: P,
 //!     ) -> Result<Vec<Fileinfo<PathBuf, Self::Metadata>>>
 //!     where
@@ -59,7 +59,7 @@
 //!
 //!     async fn get<P: AsRef<Path> + Send + Debug>(
 //!         &self,
-//!         user: &Option<DefaultUser>,
+//!         user: &DefaultUser,
 //!         path: P,
 //!         start_pos: u64,
 //!     ) -> Result<Box<dyn tokio::io::AsyncRead + Send + Sync + Unpin>> {
@@ -71,7 +71,7 @@
 //!         R: tokio::io::AsyncRead + Send + Sync + Unpin + 'static,
 //!     >(
 //!         &self,
-//!         user: &Option<DefaultUser>,
+//!         user: &DefaultUser,
 //!         input: R,
 //!         path: P,
 //!         start_pos: u64,
@@ -81,7 +81,7 @@
 //!
 //!     async fn del<P: AsRef<Path> + Send + Debug>(
 //!         &self,
-//!         user: &Option<DefaultUser>,
+//!         user: &DefaultUser,
 //!         path: P,
 //!     ) -> Result<()> {
 //!         unimplemented!()
@@ -89,7 +89,7 @@
 //!
 //!     async fn mkd<P: AsRef<Path> + Send + Debug>(
 //!         &self,
-//!         user: &Option<DefaultUser>,
+//!         user: &DefaultUser,
 //!         path: P,
 //!     ) -> Result<()> {
 //!         unimplemented!()
@@ -97,7 +97,7 @@
 //!
 //!     async fn rename<P: AsRef<Path> + Send + Debug>(
 //!         &self,
-//!         user: &Option<DefaultUser>,
+//!         user: &DefaultUser,
 //!         from: P,
 //!         to: P,
 //!     ) -> Result<()> {
@@ -106,7 +106,7 @@
 //!
 //!     async fn rmd<P: AsRef<Path> + Send + Debug>(
 //!         &self,
-//!         user: &Option<DefaultUser>,
+//!         user: &DefaultUser,
 //!         path: P,
 //!     ) -> Result<()> {
 //!         unimplemented!()
@@ -114,7 +114,7 @@
 //!
 //!     async fn cwd<P: AsRef<Path> + Send + Debug>(
 //!         &self,
-//!         user: &Option<DefaultUser>,
+//!         user: &DefaultUser,
 //!         path: P,
 //!     ) -> Result<()> {
 //!         unimplemented!()


### PR DESCRIPTION
This is a breaking change to the StorageBackend trait. I realized while
implementing more storage back-ends in unFTP that there is no need to
make the user detail optional in the trait methods. For example in

```
async fn list<P: AsRef<Path> + Send + Debug>(&self, user: &User, path: P) -> ...
```

the user was previously optional (i.e. `&Optional<User>`). By the time these methods are called
we will always have a valid user. Its more that the Session struct stores it as optional and we used it as is. A future refactoring to the Session struct might split it in two, one for a pre-auth session and one for after the user was authenticated. There are some nice ways in Rust to represent different states like this. For now I just fix the storage back-end to make it more ergonomic and correct.

The other bundled change is this:

![image](https://user-images.githubusercontent.com/2511554/125047038-da7cd200-e09e-11eb-82e8-b411f60d3b60.png)

which is just a fix of a previous oversight.