### PR TITLE
Include the number of links to a file

### DIFF
--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -224,6 +224,7 @@ impl<User: UserDetail> StorageBackend<User> for Filesystem {
     }
 }
 
+#[allow(unreachable_code)]
 impl Metadata for Meta {
     fn len(&self) -> u64 {
         self.inner.len()
@@ -246,11 +247,57 @@ impl Metadata for Meta {
     }
 
     fn gid(&self) -> u32 {
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::linux::fs::MetadataExt;
+
+            return self.inner.st_gid();
+        }
+
+        #[cfg(target_os = "unix")]
+        {
+            use std::os::unix::fs::MetadataExt;
+
+            return self.inner.gid();
+        }
+
         0
     }
 
     fn uid(&self) -> u32 {
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::linux::fs::MetadataExt;
+
+            return self.inner.st_uid();
+        }
+
+        #[cfg(target_os = "unix")]
+        {
+            use std::os::unix::fs::MetadataExt;
+
+            return self.inner.uid();
+        }
+
         0
+    }
+
+    fn links(&self) -> u64 {
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::linux::fs::MetadataExt;
+
+            return self.inner.st_nlink();
+        }
+
+        #[cfg(target_os = "unix")]
+        {
+            use std::os::unix::fs::MetadataExt;
+
+            return self.inner.nlink();
+        }
+
+        1
     }
 }
 

--- a/src/storage/storage_backend.rs
+++ b/src/storage/storage_backend.rs
@@ -51,6 +51,11 @@ pub trait Metadata {
     /// Returns the `uid` of the file.
     fn uid(&self) -> u32;
 
+    /// Returns the number of links to the file. The default implementation always returns `1`
+    fn links(&self) -> u64 {
+        1
+    }
+
     /// Returns the `permissions` of the file. The default implementation assumes unix permissions
     /// and defaults to "rwxr-xr-x" (octal 7755)
     fn permissions(&self) -> Permissions {
@@ -120,7 +125,7 @@ where
         #[allow(clippy::write_literal)]
         write!(
             f,
-            "{filetype}{permissions} {owner:>12} {group:>12} {size:#14} {modified:>12} {path}",
+            "{filetype}{permissions} {links:>12} {owner:>12} {group:>12} {size:#14} {modified:>12} {path}",
             filetype = if self.metadata.is_dir() {
                 "d"
             } else if self.metadata.is_symlink() {
@@ -129,6 +134,7 @@ where
                 "-"
             },
             permissions = perms,
+            links = self.metadata.links(),
             owner = self.metadata.uid(),
             group = self.metadata.gid(),
             size = self.metadata.len(),


### PR DESCRIPTION
In the future `links` could also be implemented for windows ([if I'm reading this right](https://doc.rust-lang.org/nightly/std/os/windows/fs/trait.MetadataExt.html#tymethod.number_of_links)) and [wasi](https://doc.rust-lang.org/nightly/std/os/wasi/fs/trait.MetadataExt.html#tymethod.nlink) once the API stabilizes.

While at it also implements `gid` and `uid` for linux and unix targets.

Fixes #371 