### PR TITLE
Replace futures with futures-util and use tokio's mpsc channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitflags = "1.2.1"
 bytes = "1.0.1"
 chrono = { version = "0.4.19", default-features = false, features = ["std"] }
 derive_more = { version = "0.99.16", features = ["display"] }
-futures = { version = "0.3.15", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.15", default-features = false, features = ["alloc", "sink"] }
 getrandom = "0.2"
 lazy_static = "1.4.0"
 md-5 = "0.9.1"
@@ -46,8 +46,7 @@ rustls = "0.19.1"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_info"] }
 slog-stdlog = "4.1.0"
 thiserror = "1.0.26"
-tokio = { version = "1.8.1", features = ["rt", "net", "sync", "io-util", "time"] }
-tokio-stream = "0.1.7"
+tokio = { version = "1.8.1", features = ["macros", "rt", "net", "sync", "io-util", "time"] }
 tokio-rustls = { version = "0.22.0" }
 tokio-util = { version = "0.6.7", features = ["codec"] }
 tracing = { version = "0.1.26", default-features = false }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -56,7 +56,7 @@ lazy_static! {
 fn add_event_metric(event: &Event) {
     match event {
         Event::Command(cmd) => {
-            add_command_metric(&cmd);
+            add_command_metric(cmd);
         }
         Event::InternalMsg(msg) => match msg {
             ControlChanMsg::SendData { bytes } => {

--- a/src/server/chancomms.rs
+++ b/src/server/chancomms.rs
@@ -6,7 +6,7 @@ use crate::{
     server::controlchan::Reply,
     storage::{Error, StorageBackend},
 };
-use futures::channel::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::{Receiver, Sender};
 
 // Commands that can be send to the data channel / data loop.
 #[derive(PartialEq, Debug)]

--- a/src/server/controlchan/commands/abor.rs
+++ b/src/server/controlchan/commands/abor.rs
@@ -19,7 +19,6 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::prelude::*;
 
 #[derive(Debug)]
 pub struct Abor;
@@ -36,7 +35,7 @@ where
         let mut session = args.session.lock().await;
         let logger = args.logger;
         match session.data_abort_tx.take() {
-            Some(mut tx) => {
+            Some(tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(()).await {
                         slog::warn!(logger, "abort failed: {}", err);

--- a/src/server/controlchan/commands/auth.rs
+++ b/src/server/controlchan/commands/auth.rs
@@ -17,7 +17,6 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::prelude::*;
 
 // The parameter that can be given to the `AUTH` command.
 #[derive(Debug, PartialEq, Clone)]
@@ -46,7 +45,7 @@ where
 {
     #[tracing_attributes::instrument]
     async fn handle(&self, args: CommandContext<Storage, User>) -> Result<Reply, ControlChanError> {
-        let mut tx = args.tx_control_chan.clone();
+        let tx = args.tx_control_chan.clone();
         let logger = args.logger;
         match (args.tls_configured, self.protocol.clone()) {
             (true, AuthParam::Tls) => {

--- a/src/server/controlchan/commands/cwd.rs
+++ b/src/server/controlchan/commands/cwd.rs
@@ -20,7 +20,6 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::prelude::*;
 use std::{path::PathBuf, sync::Arc};
 
 #[derive(Debug)]
@@ -46,8 +45,8 @@ where
         let mut session = args.session.lock().await;
         let storage: Arc<Storage> = Arc::clone(&session.storage);
         let path = session.cwd.join(self.path.clone());
-        let mut tx_success = args.tx_control_chan.clone();
-        let mut tx_fail = args.tx_control_chan.clone();
+        let tx_success = args.tx_control_chan.clone();
+        let tx_fail = args.tx_control_chan.clone();
         let logger = args.logger;
 
         if let Err(err) = storage.cwd((*session.user).as_ref().unwrap(), path.clone()).await {

--- a/src/server/controlchan/commands/dele.rs
+++ b/src/server/controlchan/commands/dele.rs
@@ -18,8 +18,8 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::{channel::mpsc::Sender, prelude::*};
 use std::{string::String, sync::Arc};
+use tokio::sync::mpsc::Sender;
 
 #[derive(Debug)]
 pub struct Dele {
@@ -45,8 +45,8 @@ where
         let storage = Arc::clone(&session.storage);
         let user = session.user.clone();
         let path = session.cwd.join(self.path.clone());
-        let mut tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
-        let mut tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
         let logger = args.logger;
         tokio::spawn(async move {
             match storage.del((*user).as_ref().unwrap(), path).await {

--- a/src/server/controlchan/commands/list.rs
+++ b/src/server/controlchan/commands/list.rs
@@ -24,7 +24,6 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::prelude::*;
 
 #[derive(Debug)]
 pub struct List;
@@ -45,7 +44,7 @@ where
         };
         let logger = args.logger;
         match session.data_cmd_tx.take() {
-            Some(mut tx) => {
+            Some(tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(cmd).await {
                         slog::warn!(logger, "could not notify data channel to respond with LIST. {}", err);

--- a/src/server/controlchan/commands/md5.rs
+++ b/src/server/controlchan/commands/md5.rs
@@ -12,8 +12,8 @@ use crate::{
     storage::{StorageBackend, FEATURE_SITEMD5},
 };
 use async_trait::async_trait;
-use futures::{channel::mpsc::Sender, prelude::*};
 use std::{path::PathBuf, sync::Arc};
+use tokio::sync::mpsc::Sender;
 
 #[derive(Debug)]
 pub struct Md5 {
@@ -38,8 +38,8 @@ where
         let user = session.user.clone();
         let storage = Arc::clone(&session.storage);
         let path = session.cwd.join(self.path.clone());
-        let mut tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
-        let mut tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
         let logger = args.logger;
 
         match args.sitemd5 {

--- a/src/server/controlchan/commands/mdtm.rs
+++ b/src/server/controlchan/commands/mdtm.rs
@@ -12,8 +12,8 @@ use crate::{
 };
 use async_trait::async_trait;
 use chrono::{offset::Utc, DateTime};
-use futures::{channel::mpsc::Sender, prelude::*};
 use std::{path::PathBuf, sync::Arc};
+use tokio::sync::mpsc::Sender;
 
 const RFC3659_TIME: &str = "%Y%m%d%H%M%S";
 
@@ -41,8 +41,8 @@ where
         let user = session.user.clone();
         let storage = Arc::clone(&session.storage);
         let path = session.cwd.join(self.path.clone());
-        let mut tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
-        let mut tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
         let logger = args.logger;
 
         tokio::spawn(async move {

--- a/src/server/controlchan/commands/mkd.rs
+++ b/src/server/controlchan/commands/mkd.rs
@@ -18,8 +18,8 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::{channel::mpsc::Sender, prelude::*};
 use std::{path::PathBuf, sync::Arc};
+use tokio::sync::mpsc::Sender;
 
 #[derive(Debug)]
 pub struct Mkd {
@@ -45,8 +45,8 @@ where
         let user = session.user.clone();
         let storage = Arc::clone(&session.storage);
         let path: PathBuf = session.cwd.join(self.path.clone());
-        let mut tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
-        let mut tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
         let logger = args.logger;
         tokio::spawn(async move {
             if let Err(err) = storage.mkd((*user).as_ref().unwrap(), &path).await {

--- a/src/server/controlchan/commands/nlst.rs
+++ b/src/server/controlchan/commands/nlst.rs
@@ -25,7 +25,6 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::prelude::*;
 
 #[derive(Debug)]
 pub struct Nlst;
@@ -46,7 +45,7 @@ where
         };
         let logger = args.logger;
         match session.data_cmd_tx.take() {
-            Some(mut tx) => {
+            Some(tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(cmd).await {
                         slog::warn!(logger, "{}", err);

--- a/src/server/controlchan/commands/pass.rs
+++ b/src/server/controlchan/commands/pass.rs
@@ -25,8 +25,8 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::{channel::mpsc::Sender, prelude::*};
 use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
 
 #[derive(Debug)]
 pub struct Pass {
@@ -52,7 +52,7 @@ where
         let logger = args.logger;
         match &session.state {
             SessionState::WaitPass => {
-                let pass: &str = std::str::from_utf8(&self.password.as_ref())?;
+                let pass: &str = std::str::from_utf8(self.password.as_ref())?;
                 let pass: String = pass.to_string();
                 let user: String = match session.username.clone() {
                     Some(v) => v,
@@ -61,7 +61,7 @@ where
                         return Ok(Reply::new(ReplyCode::NotLoggedIn, "Please open a new connection to re-authenticate"));
                     }
                 };
-                let mut tx: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+                let tx: Sender<ControlChanMsg> = args.tx_control_chan.clone();
 
                 let auther = args.authenticator.clone();
 

--- a/src/server/controlchan/commands/pasv.rs
+++ b/src/server/controlchan/commands/pasv.rs
@@ -23,13 +23,10 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::{
-    channel::mpsc::{channel, Receiver, Sender},
-    prelude::*,
-};
 use std::net::Ipv4Addr;
 use std::{io, net::SocketAddr, ops::Range};
 use tokio::net::TcpListener;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 const BIND_RETRIES: u8 = 10;
 
@@ -141,7 +138,7 @@ impl Pasv {
     // For proxy mode we prepare the session and let the proxy loop know (via channel) that it
     // should choose a data port and check for connections on it.
     #[tracing_attributes::instrument]
-    async fn handle_proxy_mode<S, U>(&self, args: CommandContext<S, U>, mut tx: ProxyLoopSender<S, U>) -> Result<Reply, ControlChanError>
+    async fn handle_proxy_mode<S, U>(&self, args: CommandContext<S, U>, tx: ProxyLoopSender<S, U>) -> Result<Reply, ControlChanError>
     where
         U: UserDetail + 'static,
         S: StorageBackend<U> + 'static,

--- a/src/server/controlchan/commands/quit.rs
+++ b/src/server/controlchan/commands/quit.rs
@@ -25,7 +25,7 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::{channel::mpsc::Sender, prelude::*};
+use tokio::sync::mpsc::Sender;
 
 #[derive(Debug)]
 pub struct Quit;
@@ -39,7 +39,7 @@ where
 {
     #[tracing_attributes::instrument]
     async fn handle(&self, args: CommandContext<Storage, User>) -> Result<Reply, ControlChanError> {
-        let mut tx: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx: Sender<ControlChanMsg> = args.tx_control_chan.clone();
         let logger = args.logger;
         // Let the control loop know it can exit.
         if let Err(send_res) = tx.send(ControlChanMsg::Quit).await {

--- a/src/server/controlchan/commands/retr.rs
+++ b/src/server/controlchan/commands/retr.rs
@@ -20,7 +20,6 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::prelude::*;
 
 #[derive(Debug)]
 pub struct Retr;
@@ -41,7 +40,7 @@ where
         };
         let logger = args.logger;
         match session.data_cmd_tx.take() {
-            Some(mut tx) => {
+            Some(tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(cmd).await {
                         slog::warn!(logger, "{}", err);

--- a/src/server/controlchan/commands/rmd.rs
+++ b/src/server/controlchan/commands/rmd.rs
@@ -18,7 +18,6 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::prelude::*;
 use std::{string::String, sync::Arc};
 
 #[derive(Debug)]
@@ -44,8 +43,8 @@ where
         let session = args.session.lock().await;
         let storage: Arc<Storage> = Arc::clone(&session.storage);
         let path = session.cwd.join(self.path.clone());
-        let mut tx_success = args.tx_control_chan.clone();
-        let mut tx_fail = args.tx_control_chan.clone();
+        let tx_success = args.tx_control_chan.clone();
+        let tx_fail = args.tx_control_chan.clone();
         let logger = args.logger;
         if let Err(err) = storage.rmd((*session.user).as_ref().unwrap(), path).await {
             slog::warn!(logger, "Failed to delete directory: {}", err);

--- a/src/server/controlchan/commands/size.rs
+++ b/src/server/controlchan/commands/size.rs
@@ -11,8 +11,8 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::{channel::mpsc::Sender, prelude::*};
 use std::{path::PathBuf, sync::Arc};
+use tokio::sync::mpsc::Sender;
 
 #[derive(Debug)]
 pub struct Size {
@@ -38,8 +38,8 @@ where
         let user = session.user.clone();
         let storage: Arc<Storage> = Arc::clone(&session.storage);
         let path = session.cwd.join(self.path.clone());
-        let mut tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
-        let mut tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
         let logger = args.logger;
 
         tokio::spawn(async move {

--- a/src/server/controlchan/commands/stat.rs
+++ b/src/server/controlchan/commands/stat.rs
@@ -31,8 +31,8 @@ use crate::{
 };
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::{channel::mpsc::Sender, prelude::*};
 use std::{io::Read, sync::Arc};
+use tokio::sync::mpsc::Sender;
 
 #[derive(Debug)]
 pub struct Stat {
@@ -81,8 +81,8 @@ where
                 let user = session.user.clone();
                 let storage = Arc::clone(&session.storage);
 
-                let mut tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
-                let mut tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+                let tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+                let tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
                 let logger = args.logger;
 
                 tokio::spawn(async move {

--- a/src/server/controlchan/commands/stor.rs
+++ b/src/server/controlchan/commands/stor.rs
@@ -20,7 +20,6 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::prelude::*;
 
 #[derive(Debug)]
 pub struct Stor;
@@ -41,7 +40,7 @@ where
         };
         let logger = args.logger;
         match session.data_cmd_tx.take() {
-            Some(mut tx) => {
+            Some(tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(cmd).await {
                         slog::warn!(logger, "{}", err);

--- a/src/server/controlchan/commands/stou.rs
+++ b/src/server/controlchan/commands/stou.rs
@@ -11,7 +11,6 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::prelude::*;
 use std::path::Path;
 use uuid::Uuid;
 
@@ -34,7 +33,7 @@ where
         let path: String = session.cwd.join(&filename).to_string_lossy().to_string();
         let logger = args.logger;
         match session.data_cmd_tx.take() {
-            Some(mut tx) => {
+            Some(tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(DataChanCmd::Stor { path }).await {
                         slog::warn!(logger, "sending command failed. {}", err);

--- a/src/server/controlchan/commands/user.rs
+++ b/src/server/controlchan/commands/user.rs
@@ -84,7 +84,6 @@ mod tests {
     use crate::storage::{Metadata, StorageBackend};
     use async_trait::async_trait;
     use bytes::Bytes;
-    use futures::channel::mpsc;
     use pretty_assertions::assert_eq;
     use slog::o;
     use std::fmt::Debug;
@@ -92,6 +91,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::SystemTime;
     use tokio::io::AsyncRead;
+    use tokio::sync::mpsc;
     use tokio::sync::Mutex;
 
     #[derive(Debug)]

--- a/src/server/controlchan/handler.rs
+++ b/src/server/controlchan/handler.rs
@@ -10,8 +10,8 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use futures::channel::mpsc::Sender;
 use std::{ops::Range, result::Result, sync::Arc};
+use tokio::sync::mpsc::Sender;
 
 // Common interface for all handlers of `Commands`
 #[async_trait]

--- a/src/server/controlchan/line_parser/parser.rs
+++ b/src/server/controlchan/line_parser/parser.rs
@@ -117,7 +117,7 @@ where
             let path = line
                 .split(|&b| b == b' ')
                 .filter(|s| !line.is_empty() && !s.starts_with(b"-"))
-                .map(|s| String::from_utf8_lossy(&s).to_string())
+                .map(|s| String::from_utf8_lossy(s).to_string())
                 .next();
             // Note that currently we just throw arguments away.
             Command::List { options: None, path }
@@ -328,7 +328,7 @@ where
             Command::Mdtm { file }
         }
         "SITE" => {
-            let (cmd_token, cmd_params) = split_token_params(&cmd_params);
+            let (cmd_token, cmd_params) = split_token_params(cmd_params);
             let cmd_token = normalize(cmd_token)?;
 
             match &*cmd_token {

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -8,13 +8,13 @@ use crate::{
     metrics,
     storage::{Metadata, StorageBackend},
 };
-use futures::channel::mpsc::{Receiver, Sender};
 use std::{
     fmt::{Debug, Formatter},
     net::SocketAddr,
     path::PathBuf,
     sync::Arc,
 };
+use tokio::sync::mpsc::{Receiver, Sender};
 
 // TraceId is an identifier used to correlate logs statements together.
 #[derive(PartialEq, Eq, Debug)]


### PR DESCRIPTION
Drops dependency on `futures`, `futures-channel` (which was being imported by `futures`) and `tokio-stream`.

Also while testing it I used [feature resolver v2](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver) and noticed tokio should also have been imported with the `macros` feature, which is required in order for `tokio::select!` to work.