### PR TITLE
Add shutdown grace period

### DIFF
--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -187,7 +187,7 @@ where
             match incoming {
                 None => {} // Loop again
                 Some(Ok(Event::InternalMsg(ControlChanMsg::Quit))) => {
-                    slog::info!(logger, "Upgrading control channel to TLS");
+                    slog::info!(logger, "Exiting control loop");
                     return;
                 }
                 Some(Ok(event)) => {

--- a/src/server/ftpserver/error.rs
+++ b/src/server/ftpserver/error.rs
@@ -34,3 +34,15 @@ impl From<std::io::Error> for ServerError {
         ServerError::new("io error", e)
     }
 }
+
+#[derive(Error, Debug)]
+#[error("shutdown error: {msg}")]
+pub struct ShutdownError {
+    pub msg: String,
+}
+
+impl From<ShutdownError> for ServerError {
+    fn from(e: ShutdownError) -> Self {
+        ServerError::new("shutdown error", e)
+    }
+}

--- a/src/server/ftpserver/options.rs
+++ b/src/server/ftpserver/options.rs
@@ -1,6 +1,7 @@
 //! Contains code pertaining to the setup options that can be given to the [`Server`](crate::Server)
 
 use bitflags::bitflags;
+use std::time::Duration;
 use std::{
     fmt::Formatter,
     fmt::{self, Debug, Display},
@@ -177,7 +178,7 @@ impl Default for SiteMd5 {
 
 /// The options for [Server.shutdown_indicator](crate::Server::shutdown_indicator) that allows users
 /// to specify the way in which a (graceful) shutdown of libunftp should happen.
-pub enum Shutdown<Signal: Future<Output = ()> + Send + Sync> {
+pub enum Shutdown<Signal: Future<Output = Duration> + Send + Sync> {
     /// No shutdown signal will be adhered to.
     ///
     /// This will cause libunftp to keep on running as long as the future returned
@@ -199,7 +200,7 @@ pub enum Shutdown<Signal: Future<Output = ()> + Send + Sync> {
     GracefulBlockingConnections(Signal),
 }
 
-impl<Signal: Future<Output = ()> + Send + Sync> Default for Shutdown<Signal> {
+impl<Signal: Future<Output = Duration> + Send + Sync> Default for Shutdown<Signal> {
     fn default() -> Self {
         Shutdown::None
     }


### PR DESCRIPTION
Improvement for #386

When doing a graceful shutdown you don't want things to take to long, so a grace period can be specified.

Logs for shutdown within grace period:

```
 Nov 12 16:07:19.160 INFO Shutting down FTP server
 Nov 12 16:07:19.160 INFO HTTP shutdown OK
lib: libunftp
 Nov 12 16:07:19.160 DEBG Shutting down within 10s
 Nov 12 16:07:19.161 DEBG Graceful shutdown complete
module: main
```

and the not so happy case:

```
 Nov 12 16:27:35.985 INFO HTTP shutdown OK
lib: libunftp
 Nov 12 16:27:35.985 DEBG Shutting down within 10s
 trace-id: 0x45bb0af218d17c28
  source: 127.0.0.1:57427
   Nov 12 16:27:35.985 INFO Shutting down control loop
 Nov 12 16:27:45.987 WARN Could not finish shutdown normally within grace period
module: main
 Nov 12 16:27:45.988 ERRO FTP server error: ServerError { msg: "shutdown error", source: ShutdownError { msg: "shutdown grace period expired" } }
 Nov 12 16:27:45.988 INFO FTP exiting

```