### PR TITLE
Add event label to ftp_reply_total metric

### DIFF
--- a/src/server/chancomms.rs
+++ b/src/server/chancomms.rs
@@ -1,12 +1,13 @@
 //! Contains code pertaining to the communication between the data and control channels.
 
 use super::session::SharedSession;
-use crate::server::session::TraceId;
 use crate::{
     auth::UserDetail,
     server::controlchan::Reply,
+    server::session::TraceId,
     storage::{Error, StorageBackend},
 };
+use std::fmt;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 // Commands that can be send to the data channel / data loop.
@@ -123,6 +124,12 @@ pub enum ControlChanMsg {
     StorageError(Error),
     /// Reply on the command channel
     CommandChannelReply(Reply),
+}
+
+impl fmt::Display for ControlChanMsg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
 }
 
 // ProxyLoopMsg is sent to the proxy loop when proxy protocol mode is enabled. See the


### PR DESCRIPTION
The `ftp_reply_total` metric had no way to correlate it back to the type
of event for which a reply is given. I've changed this now so that the
metrics would look something like this:

```
clients.
ftp_reply_total{event="auth",event_type="command",range="2xx"} 1
ftp_reply_total{event="authsuccess",event_type="ctrl-chan-msg",range="2xx"}
1
ftp_reply_total{event="directorysuccessfullylisted",event_type="ctrl-chan-msg",range="2xx"}
1
ftp_reply_total{event="feat",event_type="command",range="2xx"} 1
ftp_reply_total{event="list",event_type="command",range="1xx"} 1
ftp_reply_total{event="opts",event_type="command",range="2xx"} 1
ftp_reply_total{event="pasv",event_type="command",range="2xx"} 1
ftp_reply_total{event="pbsz",event_type="command",range="2xx"} 1
ftp_reply_total{event="prot",event_type="command",range="2xx"} 1
ftp_reply_total{event="user",event_type="command",range="3xx"} 1
```

Notice the new `event` and `event_type` labels.

The same was done for the `ftp_error_total` metric.