### PR TITLE
Fix issue where the control loop did not exit

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -73,6 +73,9 @@ fn add_event_metric(event: &Event) {
                 FTP_BACKEND_WRITE_BYTES.inc_by(*bytes);
                 FTP_BACKEND_WRITE_FILES.inc();
             }
+            ControlChanMsg::AuthFailed => {
+                FTP_AUTH_FAILURES.inc();
+            }
             _ => {}
         },
     }

--- a/src/server/chancomms.rs
+++ b/src/server/chancomms.rs
@@ -79,8 +79,6 @@ pub enum ControlChanMsg {
     DataConnectionClosedAfterStor,
     /// Failed to write data to disk
     WriteFailed,
-    /// Unknown Error retrieving file
-    UnknownRetrieveError,
     /// Listed the directory successfully
     DirectorySuccessfullyListed,
     /// Failed to list the directory contents


### PR DESCRIPTION
Our logic in the control loop didn't actually detect a disconnect on the
TCP stream which meant the control loop won't exit if the client
abruptly disconnects. It would only disconnect after the idle timeout.
This is obviously not good so herewith the fix.