### PR TITLE
Allow lowercase UTF8 OPTS

### DIFF
--- a/src/server/controlchan/line_parser/parser.rs
+++ b/src/server/controlchan/line_parser/parser.rs
@@ -168,10 +168,10 @@ where
             }
 
             match &params[..] {
-                b"UTF8 ON" => Command::Opts {
+                b"UTF8 ON" | b"utf8 on" => Command::Opts {
                     option: Opt::Utf8 { on: true },
                 },
-                b"UTF8 OFF" => Command::Opts {
+                b"UTF8 OFF" | b"utf8 off" => Command::Opts {
                     option: Opt::Utf8 { on: false },
                 },
                 _ => return Err(ParseErrorKind::InvalidCommand.into()),


### PR DESCRIPTION
The FTP client included in Windows Explorer sends this command in lowercase. Without this patch the server would respond with an invalid command error and the client would refuse to continue.

Wireshark trace for reference:
![winftp](https://user-images.githubusercontent.com/725423/174318960-bc351927-0b8b-498c-a983-ac4ba0a055f5.png)

