### PR TITLE
Fix windows paths

### DIFF
--- a/src/server/proxy_protocol.rs
+++ b/src/server/proxy_protocol.rs
@@ -219,7 +219,7 @@ where
 mod tests {
     use super::ProxyError;
     use proxy_protocol::{version1::ProxyAddresses, ProxyHeader};
-    use std::net::SocketAddrV4;
+    use std::net::{SocketAddrV4, Ipv4Addr};
     use std::time::Duration;
     use tokio::io::AsyncWriteExt;
     use tokio::time::sleep;


### PR DESCRIPTION
This fixes the display issues mentioned in https://github.com/bolcom/libunftp/pull/413#issuecomment-1158995676, for all the FTP clients I've tested.

I also added a missing import that was making the test suite not compile. At the moment everything I've tested works correctly on Windows and all the tests pass.