### PR TITLE
Adding support for `BYE` command

### DIFF
--- a/src/server/controlchan/line_parser/parser.rs
+++ b/src/server/controlchan/line_parser/parser.rs
@@ -195,7 +195,7 @@ where
             let path = String::from_utf8_lossy(&path).to_string();
             Command::Rmd { path }
         }
-        "QUIT" => {
+        "QUIT" | "BYE" => {
             let params = parse_to_eol(cmd_params)?;
             if !params.is_empty() {
                 return Err(ParseErrorKind::InvalidCommand.into());

--- a/src/server/controlchan/line_parser/tests.rs
+++ b/src/server/controlchan/line_parser/tests.rs
@@ -330,6 +330,15 @@ fn parse_quit() {
 }
 
 #[test]
+fn parse_bye() {
+    let input = "BYE\r\n";
+    assert_eq!(parse(input), Ok(Command::Quit));
+
+    let input = "BYE BYE\r\n";
+    assert_eq!(parse(input), Err(ParseError::from(ParseErrorKind::InvalidCommand)));
+}
+
+#[test]
 fn parse_mkd() {
     let input = "MKD\r\n";
     assert_eq!(parse(input), Err(ParseError::from(ParseErrorKind::InvalidCommand)));


### PR DESCRIPTION
Should support this command as an alias of `QUIT`, some clients would use this command https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/ftp-bye