### PR TITLE
Add option to enable active or passive mode

### DIFF
--- a/src/server/controlchan/active_passive.rs
+++ b/src/server/controlchan/active_passive.rs
@@ -1,0 +1,34 @@
+use crate::{
+    options::ActivePassiveMode,
+    server::{
+        controlchan::{error::ControlChanError, middleware::ControlChanMiddleware},
+        Command, Event, Reply, ReplyCode,
+    },
+};
+use async_trait::async_trait;
+
+// Control channel middleware that enforces disables Active or Passive mode depending on the
+// setting of [`DataConnectionMode`](DataConnectionMode).
+pub struct ActivePassiveEnforcerMiddleware<Next>
+where
+    Next: ControlChanMiddleware,
+{
+    pub mode: ActivePassiveMode,
+    pub next: Next,
+}
+
+#[async_trait]
+impl<Next> ControlChanMiddleware for ActivePassiveEnforcerMiddleware<Next>
+where
+    Next: ControlChanMiddleware,
+{
+    async fn handle(&mut self, event: Event) -> Result<Reply, ControlChanError> {
+        match (self.mode, &event) {
+            (ActivePassiveMode::PassiveOnly, Event::Command(Command::Port { .. })) => {
+                Ok(Reply::new(ReplyCode::CommandNotImplemented, "Active mode not enabled."))
+            }
+            (ActivePassiveMode::ActiveOnly, Event::Command(Command::Pasv)) => Ok(Reply::new(ReplyCode::CommandNotImplemented, "Passive mode not enabled.")),
+            _ => self.next.handle(event).await,
+        }
+    }
+}

--- a/src/server/controlchan/mod.rs
+++ b/src/server/controlchan/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod reply;
 
 pub(super) mod commands;
 
+mod active_passive;
 mod auth;
 mod codecs;
 mod control_loop;

--- a/src/server/ftpserver/chosen.rs
+++ b/src/server/ftpserver/chosen.rs
@@ -1,6 +1,7 @@
 //! Represents the chosen options that the libunftp user opted for.
 
 use crate::notification::{DataListener, PresenceListener};
+use crate::options::ActivePassiveMode;
 use crate::storage::Metadata;
 use crate::{
     auth::Authenticator,
@@ -32,6 +33,7 @@ where
     pub site_md5: SiteMd5,
     pub data_listener: Arc<dyn DataListener>,
     pub presence_listener: Arc<dyn PresenceListener>,
+    pub active_passive_mode: ActivePassiveMode,
 }
 
 impl<Storage, User> From<&OptionsHolder<Storage, User>> for controlchan::LoopConfig<Storage, User>
@@ -56,6 +58,7 @@ where
             site_md5: server.site_md5,
             data_listener: server.data_listener.clone(),
             presence_listener: server.presence_listener.clone(),
+            active_passive_mode: server.active_passive_mode,
         }
     }
 }

--- a/src/server/ftpserver/options.rs
+++ b/src/server/ftpserver/options.rs
@@ -240,3 +240,16 @@ impl Default for FailedLoginsPolicy {
         FailedLoginsPolicy::new(3, Duration::from_secs(120), FailedLoginsBlock::UserAndIP)
     }
 }
+
+/// The options for [Server.active_passive_mode](crate::Server::active_passive_mode).
+/// This allows to switch active / passive mode on or off.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+pub enum ActivePassiveMode {
+    /// Only passive mode is enabled
+    #[default]
+    PassiveOnly,
+    /// Only Active mode is enabled
+    ActiveOnly,
+    /// Both is enabled
+    ActiveAndPassive,
+}

--- a/src/server/password.rs
+++ b/src/server/password.rs
@@ -45,7 +45,7 @@ mod tests {
     const SECRET: &str = "supersecret";
 
     #[test]
-    fn password_obsures_display() {
+    fn password_obscures_display() {
         assert_eq!("*******", format!("{}", password()));
     }
 


### PR DESCRIPTION
This adds functionality to libunftp to disable either Active Mode or Passive Mode or have both enabled. The default is to have only Passive mode (PASV) enabled since active mode is older and considered less secure.

If a client connects and uses PORT or PASV when it is disabled we return FTP code `502` (command not implemented)