### PR TITLE
Numerous improvements on logging and metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## upcoming
+
+- Cleaned INFO log output
+- New metrics (ftp_transferred_total, ftp_sent_bytes, ftp_received_bytes)
+- Useful new log messages such as data command summary with transfer speed
+- Various bug fixes (RETR reply on missing data connection, mapping to correct ftp errors)
+
 ## 2023-01-25 Release of all crates
 
 ### libunftp 0.18.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Cleaned INFO log output
 - New metrics (ftp_transferred_total, ftp_sent_bytes, ftp_received_bytes)
 - Useful new log messages such as data command summary with transfer speed
-- Various bug fixes (RETR reply on missing data connection, mapping to correct ftp errors)
+- Fixed bug where REST command didn't work correctly
+- Various other bug fixes (RETR reply on missing data connection, mapping to correct ftp errors)
 
 ## 2023-01-25 Release of all crates
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ tracing-attributes = "0.1.24"
 uuid = { version = "1.3.3", features = ["v4"] }
 x509-parser = "0.14.0"
 dashmap = "5.4.0"
+libc = "0.2"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/src/server/controlchan/commands/auth.rs
+++ b/src/server/controlchan/commands/auth.rs
@@ -51,7 +51,7 @@ where
             (true, AuthParam::Tls) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(ControlChanMsg::SecureControlChannel).await {
-                        slog::warn!(logger, "{}", err);
+                        slog::warn!(logger, "AUTH: Could not send internal message to notify of TLS upgrade: {}", err);
                     }
                 });
                 Ok(Reply::new(ReplyCode::AuthOkayNoDataNeeded, "Upgrading to TLS"))

--- a/src/server/controlchan/commands/cwd.rs
+++ b/src/server/controlchan/commands/cwd.rs
@@ -50,7 +50,7 @@ where
         let logger = args.logger;
 
         if let Err(err) = storage.cwd((*session.user).as_ref().unwrap(), path.clone()).await {
-            slog::warn!(logger, "CWD: Failed to cwd directory: {}", err);
+            slog::warn!(logger, "CWD: Failed to cwd directory {:?}: {} ", path, err);
             let r = tx_fail.send(ControlChanMsg::StorageError(err)).await;
             if let Err(e) = r {
                 slog::warn!(logger, "CWD: Could not send internal message to notify of CWD error: {}", e);

--- a/src/server/controlchan/commands/cwd.rs
+++ b/src/server/controlchan/commands/cwd.rs
@@ -50,16 +50,16 @@ where
         let logger = args.logger;
 
         if let Err(err) = storage.cwd((*session.user).as_ref().unwrap(), path.clone()).await {
-            slog::warn!(logger, "Failed to cwd directory: {}", err);
+            slog::warn!(logger, "CWD: Failed to cwd directory: {}", err);
             let r = tx_fail.send(ControlChanMsg::StorageError(err)).await;
             if let Err(e) = r {
-                slog::warn!(logger, "Could not send internal message to notify of CWD error: {}", e);
+                slog::warn!(logger, "CWD: Could not send internal message to notify of CWD error: {}", e);
             }
         } else {
             let r = tx_success.send(ControlChanMsg::CwdSuccess).await;
             session.cwd.push(path);
             if let Err(e) = r {
-                slog::warn!(logger, "Could not send internal message to notify of CWD success: {}", e);
+                slog::warn!(logger, "CWD: Could not send internal message to notify of CWD success: {}", e);
             }
         }
 

--- a/src/server/controlchan/commands/cwd.rs
+++ b/src/server/controlchan/commands/cwd.rs
@@ -50,7 +50,7 @@ where
         let logger = args.logger;
 
         if let Err(err) = storage.cwd((*session.user).as_ref().unwrap(), path.clone()).await {
-            slog::warn!(logger, "CWD: Failed to cwd directory {:?}: {} ", path, err);
+            slog::warn!(logger, "CWD: Failed to change directory {:?}: {} ", path, err);
             let r = tx_fail.send(ControlChanMsg::StorageError(err)).await;
             if let Err(e) = r {
                 slog::warn!(logger, "CWD: Could not send internal message to notify of CWD error: {}", e);

--- a/src/server/controlchan/commands/dele.rs
+++ b/src/server/controlchan/commands/dele.rs
@@ -52,13 +52,14 @@ where
         tokio::spawn(async move {
             match storage.del((*user).as_ref().unwrap(), path).await {
                 Ok(_) => {
+                    slog::info!(logger, "DELE: Successfully removed file {:?}", path_str);
                     if let Err(err) = tx_success.send(ControlChanMsg::DelFileSuccess { path: path_str }).await {
-                        slog::warn!(logger, "{}", err);
+                        slog::warn!(logger, "DELE: Could not send internal message to notify of DELE success: {}", err);
                     }
                 }
                 Err(err) => {
                     if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(err)).await {
-                        slog::warn!(logger, "{}", err);
+                        slog::warn!(logger, "DELE: Could not send internal message to notify of DELE error: {}", err);
                     }
                 }
             }

--- a/src/server/controlchan/commands/md5.rs
+++ b/src/server/controlchan/commands/md5.rs
@@ -73,12 +73,13 @@ where
                         )))
                         .await
                     {
-                        slog::warn!(logger, "{}", err);
+                        slog::warn!(logger, "MD5: Could not send internal message to notify of MD5 success: {}", err);
                     }
                 }
                 Err(err) => {
+                    slog::warn!(logger, "MD5: Failed to retrieve MD5 sum for {:?} from backend: {}", path, err);
                     if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(err)).await {
-                        slog::warn!(logger, "{}", err);
+                        slog::warn!(logger, "MD5: Could not send internal message to notify of MD5 failure: {}", err);
                     }
                 }
             }

--- a/src/server/controlchan/commands/mdtm.rs
+++ b/src/server/controlchan/commands/mdtm.rs
@@ -73,7 +73,7 @@ where
                             )))
                             .await
                         {
-                            slog::warn!(logger, "MDTM: Could not send internal message to notify of MDTM failure: {}", err);
+                            slog::warn!(logger, "MDTM: Could not send internal message to notify of MDTM success: {}", err);
                         }
                     }
                 }

--- a/src/server/controlchan/commands/mdtm.rs
+++ b/src/server/controlchan/commands/mdtm.rs
@@ -51,14 +51,21 @@ where
                     let modification_time = match metadata.modified() {
                         Ok(v) => Some(v),
                         Err(err) => {
+                            slog::warn!(
+                                logger,
+                                "MDTM: Could not get the modified time from the fetched metadata for path {:?}: {}",
+                                path,
+                                err
+                            );
                             if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(err)).await {
-                                slog::warn!(logger, "{}", err);
+                                slog::warn!(logger, "MDTM: Could not send internal message to notify of MDTM failure: {}", err);
                             };
                             None
                         }
                     };
 
                     if let Some(mtime) = modification_time {
+                        slog::info!(logger, "MDTM: Successfully fetched modification time for path {:?}", path);
                         if let Err(err) = tx_success
                             .send(ControlChanMsg::CommandChannelReply(Reply::new_with_string(
                                 ReplyCode::FileStatus,
@@ -66,7 +73,7 @@ where
                             )))
                             .await
                         {
-                            slog::warn!(logger, "{}", err);
+                            slog::warn!(logger, "MDTM: Could not send internal message to notify of MDTM failure: {}", err);
                         }
                     }
                 }

--- a/src/server/controlchan/commands/pass.rs
+++ b/src/server/controlchan/commands/pass.rs
@@ -87,7 +87,7 @@ where
                                     if let Some(state) = result {
                                         slog::warn!(
                                             logger,
-                                            "User authenticated but currently locked out due to previous failed login attempts according to the policy! (Username={}. Note: the account automatically unlocks after the configured period if no further failed login attempts occur. state={:?})",
+                                            "PASS: User authenticated but currently locked out due to previous failed login attempts according to the policy! (Username={}. Note: the account automatically unlocks after the configured period if no further failed login attempts occur. state={:?})",
                                             username,
                                             state
                                         );
@@ -104,23 +104,23 @@ where
                                 ControlChanMsg::AuthFailed
                             } else if user.account_enabled() {
                                 let mut session = session2clone.lock().await;
-                                slog::info!(logger, "User {} logged in", user);
+                                slog::info!(logger, "PASS: User {} logged in", user);
                                 session.user = Arc::new(Some(user));
                                 ControlChanMsg::AuthSuccess {
                                     username,
                                     trace_id: session.trace_id,
                                 }
                             } else {
-                                slog::warn!(logger, "User {} authenticated but account is disabled", user);
+                                slog::warn!(logger, "PASS: User {} authenticated but account is disabled", user);
                                 ControlChanMsg::AuthFailed
                             }
                         }
                         Err(crate::auth::AuthenticationError::BadUser) => {
-                            slog::warn!(logger, "Login attempt for unknown user {}", username);
+                            slog::warn!(logger, "PASS: Login attempt for unknown user {}", username);
                             ControlChanMsg::AuthFailed
                         }
                         Err(err) => {
-                            slog::warn!(logger, "Failed login attempt for user {}, reason={}", username, err);
+                            slog::warn!(logger, "PASS: Failed login attempt for user {}, reason={}", username, err);
                             if let Some(failed_logins) = failed_logins {
                                 let result = failed_logins.failed(source_ip, username.clone()).await;
                                 if let Some(state) = result {
@@ -128,7 +128,7 @@ where
                                         LockState::MaxFailuresReached => {
                                             slog::warn!(
                                                 logger,
-                                                "Maximum number bad login attempts reached according to the policy so the locking policy is now active (Username={}, IP={}, LockState={:?})",
+                                                "PASS: Maximum number bad login attempts reached according to the policy so the locking policy is now active (Username={}, IP={}, LockState={:?})",
                                                 username,
                                                 source_ip,
                                                 state
@@ -137,7 +137,7 @@ where
                                         LockState::AlreadyLocked => {
                                             slog::info!(
                                                 logger,
-                                                "Another bad login attempt but the locking policy is already active (Username={}, IP={}, LockState={:?})",
+                                                "PASS: Another bad login attempt but the locking policy is already active (Username={}, IP={}, LockState={:?})",
                                                 username,
                                                 source_ip,
                                                 state
@@ -152,7 +152,7 @@ where
                     };
                     tokio::spawn(async move {
                         if let Err(err) = tx.send(msg).await {
-                            slog::warn!(logger, "{}", err);
+                            slog::warn!(logger, "PASS: Could not send internal message: {}", err);
                         }
                     });
                 });

--- a/src/server/controlchan/commands/quit.rs
+++ b/src/server/controlchan/commands/quit.rs
@@ -45,6 +45,7 @@ where
         if let Err(send_res) = tx.send(ControlChanMsg::ExitControlLoop).await {
             slog::warn!(logger, "could not send internal message: QUIT. {}", send_res);
         }
+        slog::info!(logger, "QUIT: User logged out");
         Ok(Reply::new(ReplyCode::ClosingControlConnection, "Bye!"))
     }
 }

--- a/src/server/controlchan/commands/retr.rs
+++ b/src/server/controlchan/commands/retr.rs
@@ -11,7 +11,7 @@ use crate::{
         chancomms::DataChanCmd,
         controlchan::{
             command::Command,
-            error::{ControlChanError, ControlChanErrorKind},
+            error::ControlChanError,
             handler::{CommandContext, CommandHandler},
             Reply,
         },
@@ -48,7 +48,9 @@ where
                 });
                 Ok(Reply::new(ReplyCode::FileStatusOkay, "Sending data"))
             }
-            None => Err(ControlChanErrorKind::InternalServerError.into()),
+            None => {
+                Ok(Reply::new(ReplyCode::CantOpenDataConnection, "No data connection established"))
+            }
         }
     }
 }

--- a/src/server/controlchan/commands/rmd.rs
+++ b/src/server/controlchan/commands/rmd.rs
@@ -47,15 +47,16 @@ where
         let tx = args.tx_control_chan.clone();
         let logger = args.logger;
         if let Err(err) = storage.rmd((*session.user).as_ref().unwrap(), path).await {
-            slog::warn!(logger, "Failed to delete directory: {}", err);
+            slog::warn!(logger, "RMD: Failed to delete directory {}: {}", path_str, err);
             let r = tx.send(ControlChanMsg::StorageError(err)).await;
             if let Err(e) = r {
-                slog::warn!(logger, "Could not send internal message to notify of RMD error: {}", e);
+                slog::warn!(logger, "RMD: Could not send internal message to notify of RMD error: {}", e);
             }
         } else {
+            slog::info!(logger, "RMD: Successfully removed directory {:?}", path_str);
             let r = tx.send(ControlChanMsg::RmDirSuccess { path: path_str }).await;
             if let Err(e) = r {
-                slog::warn!(logger, "Could not send internal message to notify of RMD success: {}", e);
+                slog::warn!(logger, "RMD: Could not send internal message to notify of RMD success: {}", e);
             }
         }
         Ok(Reply::none())

--- a/src/server/controlchan/commands/rnto.rs
+++ b/src/server/controlchan/commands/rnto.rs
@@ -52,15 +52,16 @@ where
         let user = (*session.user).as_ref().unwrap();
         let old_path = from.to_string_lossy().to_string();
         let new_path = to.to_string_lossy().to_string();
-        match storage.rename(user, from, to).await {
+        match storage.rename(user, &from, &to).await {
             Ok(_) => {
+                slog::info!(logger, "RNTO: Successfully renamed {:?} to {:?}", from, to);
                 if let Err(err) = tx_control_chan.send(ControlChanMsg::RenameSuccess { old_path, new_path }).await {
-                    slog::warn!(logger, "{}", err);
+                    slog::warn!(logger, "RNTO: Could not send internal message to notify of RNTO success: {}", err);
                 }
             }
             Err(err) => {
                 if let Err(err) = tx_control_chan.send(ControlChanMsg::StorageError(err)).await {
-                    slog::warn!(logger, "{}", err);
+                    slog::warn!(logger, "RNTO: Could not send internal message to notify of RNTO failure: {}", err);
                 }
             }
         }

--- a/src/server/controlchan/commands/stat.rs
+++ b/src/server/controlchan/commands/stat.rs
@@ -94,13 +94,13 @@ where
                                 .send(ControlChanMsg::CommandChannelReply(Reply::new_multiline(ReplyCode::CommandOkay, lines)))
                                 .await
                             {
-                                slog::warn!(logger, "{}", err);
+                                slog::warn!(logger, "STAT: Could not send internal message to notify of STAT success: {}", err);
                             }
                         }
                         Err(e) => {
                             slog::info!(logger, "STAT: Failure listing file or directory {:?}", path_str);
                             if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(Error::new(ErrorKind::LocalError, e))).await {
-                                slog::warn!(logger, "{}", err);
+                                slog::warn!(logger, "STAT: Could not send internal message to notify of STAT failure: {}", err);
                             }
                         }
                     }

--- a/src/server/controlchan/commands/stat.rs
+++ b/src/server/controlchan/commands/stat.rs
@@ -75,6 +75,7 @@ where
             }
             Some(path) => {
                 let path: &str = std::str::from_utf8(&path)?;
+                let path_str = path.to_string();
                 let path = path.to_owned();
 
                 let session = args.session.lock().await;
@@ -88,6 +89,7 @@ where
                 tokio::spawn(async move {
                     match storage.list_vec((*user).as_ref().unwrap(), path).await {
                         Ok(lines) => {
+                            slog::info!(logger, "STAT: Successfully listed file or directory {:?}", path_str);
                             if let Err(err) = tx_success
                                 .send(ControlChanMsg::CommandChannelReply(Reply::new_multiline(ReplyCode::CommandOkay, lines)))
                                 .await
@@ -96,6 +98,7 @@ where
                             }
                         }
                         Err(e) => {
+                            slog::info!(logger, "STAT: Failure listing file or directory {:?}", path_str);
                             if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(Error::new(ErrorKind::LocalError, e))).await {
                                 slog::warn!(logger, "{}", err);
                             }

--- a/src/server/controlchan/commands/stou.rs
+++ b/src/server/controlchan/commands/stou.rs
@@ -36,12 +36,15 @@ where
             Some(tx) => {
                 tokio::spawn(async move {
                     if let Err(err) = tx.send(DataChanCmd::Stor { path }).await {
-                        slog::warn!(logger, "sending command failed. {}", err);
+                        slog::warn!(logger, "STOU: could not send Stor command over data channel. {}", err);
                     }
                 });
                 Ok(Reply::new_with_string(ReplyCode::FileStatusOkay, filename.to_string_lossy().to_string()))
             }
-            None => Ok(Reply::new(ReplyCode::CantOpenDataConnection, "No data connection established")),
+            None => {
+                slog::warn!(logger, "STOR: no data connection established for STORing {:?}", path);
+                Ok(Reply::new(ReplyCode::CantOpenDataConnection, "No data connection established"))
+            }
         }
     }
 }

--- a/src/server/controlchan/commands/stou.rs
+++ b/src/server/controlchan/commands/stou.rs
@@ -42,7 +42,7 @@ where
                 Ok(Reply::new_with_string(ReplyCode::FileStatusOkay, filename.to_string_lossy().to_string()))
             }
             None => {
-                slog::warn!(logger, "STOR: no data connection established for STORing {:?}", path);
+                slog::warn!(logger, "STOU: no data connection established for STOU file {:?}", path);
                 Ok(Reply::new(ReplyCode::CantOpenDataConnection, "No data connection established"))
             }
         }

--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -206,7 +206,7 @@ where
                         };
                     },
                     _ = shutdown.listen() => {
-                        slog::warn!(logger, "Closing open control connection because of shutdown signal");
+                        slog::info!(logger, "Closing open control connection because of shutdown signal");
                         incoming = Some(Ok(Event::InternalMsg(ControlChanMsg::ExitControlLoop)))
                         // TODO: Do we want to wait a bit for a data transfer to complete i.e. session.data_busy is true?
                     }

--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -190,7 +190,7 @@ where
                         match cmd {
                             Some(cmd_result) => incoming = Some(cmd_result.map(Event::Command)),
                             None => {
-                                slog::info!(logger, "Command stream ended.");
+                                slog::info!(logger, "Control connection was closed.");
                                 incoming = Some(Ok(Event::InternalMsg(ControlChanMsg::ExitControlLoop)))
                             }
                         }
@@ -206,7 +206,7 @@ where
                         };
                     },
                     _ = shutdown.listen() => {
-                        slog::info!(logger, "Shutting down control loop");
+                        slog::warn!(logger, "Closing open control connection because of shutdown signal");
                         incoming = Some(Ok(Event::InternalMsg(ControlChanMsg::ExitControlLoop)))
                         // TODO: Do we want to wait a bit for a data transfer to complete i.e. session.data_busy is true?
                     }
@@ -220,7 +220,7 @@ where
                     if let Some(tx) = proxyloop_msg_tx {
                         tx.send(ProxyLoopMsg::CloseDataPortCommand(shared_session.clone())).await.unwrap();
                     };
-                    slog::info!(logger, "Exiting control loop");
+                    slog::debug!(logger, "Exiting control loop");
                     return;
                 }
                 Some(Ok(event)) => {

--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -398,6 +398,7 @@ where
                 ErrorKind::PermanentDirectoryNotEmpty => Ok(Reply::new(ReplyCode::FileError, "Directory not empty")),
                 ErrorKind::PermissionDenied => Ok(Reply::new(ReplyCode::FileError, "Permission denied")),
                 ErrorKind::CommandNotImplemented => Ok(Reply::new(ReplyCode::CommandNotImplemented, "Command not implemented")),
+                ErrorKind::ConnectionClosed => Ok(Reply::new(ReplyCode::ConnectionClosed, "Connection closed")),
             },
             CommandChannelReply(reply) => Ok(reply),
         }

--- a/src/server/controlchan/log.rs
+++ b/src/server/controlchan/log.rs
@@ -26,10 +26,10 @@ where
             let s: String = String::from_utf8_lossy(username).into();
             self.logger = self.logger.new(slog::o!("username" => s));
         }
-        slog::info!(self.logger, "Control channel event {:?}", event; "seq" => self.sequence_nr);
+        slog::debug!(self.logger, "Control channel event {:?}", event; "seq" => self.sequence_nr);
         let result = self.next.handle(event).await;
         match &result {
-            Ok(reply) => slog::info!(self.logger, "Control channel reply {:?}", reply; "seq" => self.sequence_nr),
+            Ok(reply) => slog::debug!(self.logger, "Control channel reply {:?}", reply; "seq" => self.sequence_nr),
             Err(error) => slog::warn!(self.logger, "Control channel error {:?}", error; "seq" => self.sequence_nr),
         };
         result

--- a/src/server/controlchan/reply.rs
+++ b/src/server/controlchan/reply.rs
@@ -1,9 +1,28 @@
+use std::fmt;
+
 /// A reply to the FTP client
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum Reply {
     None,
     CodeAndMsg { code: ReplyCode, msg: String },
     MultiLine { code: ReplyCode, lines: Vec<String> },
+}
+
+// A custom debug implementation to avoid spamming the log with a large amount of data
+impl fmt::Debug for Reply {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Reply::None => write!(f, "None"),
+            Reply::CodeAndMsg { code, msg } => write!(f, "CodeAndMsg {{ code: {:?}, msg: {:?} }}", code, msg),
+            Reply::MultiLine { code, lines } => {
+                if lines.len() > 1 {
+                    write!(f, "MultiLine {{ code: {:?}, {} lines - output omitted) }}", code, lines.len())
+                } else {
+                    write!(f, "MultiLine {{ code: {:?}, line: {:?} }}", code, lines)
+                }
+            }
+        }
+    }
 }
 
 /// The reply codes according to RFC 959.

--- a/src/server/controlchan/reply.rs
+++ b/src/server/controlchan/reply.rs
@@ -16,7 +16,7 @@ impl fmt::Debug for Reply {
             Reply::CodeAndMsg { code, msg } => write!(f, "CodeAndMsg {{ code: {:?}, msg: {:?} }}", code, msg),
             Reply::MultiLine { code, lines } => {
                 if lines.len() > 1 {
-                    write!(f, "MultiLine {{ code: {:?}, {} lines - output omitted) }}", code, lines.len())
+                    write!(f, "MultiLine {{ code: {:?}, {} lines ({}...) }}", code, lines.len(), lines[0])
                 } else {
                     write!(f, "MultiLine {{ code: {:?}, line: {:?} }}", code, lines)
                 }

--- a/src/server/ftpserver/listen_proxied.rs
+++ b/src/server/ftpserver/listen_proxied.rs
@@ -149,7 +149,8 @@ where
                 IpAddr::V6(_) => panic!("Won't happen since PASV only does IP V4."),
             };
 
-            let reply: Reply = super::controlchan::commands::make_pasv_reply(self.options.passive_host.clone(), &destination_ip, reserved_port).await;
+            let reply: Reply =
+                super::controlchan::commands::make_pasv_reply(&self.logger, self.options.passive_host.clone(), &destination_ip, reserved_port).await;
 
             let tx_some = session.control_msg_tx.clone();
             if let Some(tx) = tx_some {

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -54,10 +54,7 @@ pub enum ErrorKind {
     PermanentFileNotAvailable,
     /// Error that will cause an FTP reply code of 550 to be returned to the FTP client.
     /// The storage back-end implementation should return this if a error occurred where it doesn't
-    /// make sense for it to be retried. For example in the case where file access is denied.
-    /// Error that will cause an FTP reply code of 550 to be returned to the FTP client.
-    /// The storage back-end implementation should return this if a error occurred where it doesn't
-    /// make sense for it to be retried. For example in the case where a file is busy.
+    /// make sense for it to be retried. For example in the case where the directory doesn't exist
     #[display(fmt = "550 Permanent directory not available")]
     PermanentDirectoryNotAvailable,
     /// Error that will cause an FTP reply code of 550 to be returned to the FTP client.

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -29,6 +29,11 @@ impl Error {
     pub fn kind(&self) -> ErrorKind {
         self.kind
     }
+
+    /// Attempts to get a reference to the inner `std::io::Error` if there is one.
+    pub fn get_io_error(&self) -> Option<&std::io::Error> {
+        self.source.as_ref()?.downcast_ref::<std::io::Error>()
+    }
 }
 
 impl From<ErrorKind> for Error {
@@ -67,7 +72,11 @@ pub enum ErrorKind {
     /// make sense for it to be retried. For example in the case where file access is denied.
     #[display(fmt = "550 Permission denied")]
     PermissionDenied,
-    /// Error that will cause an FTP reply code of 451 to be returned to the FTP client. Its means
+    /// Error that will cause an FTP reply code of 426 to be returned to the FTP client. It means the transfer was
+    /// aborted, possibly by the client or because of a network issue
+    #[display(fmt = "426 Connection closed transfer aborted")]
+    ConnectionClosed,
+    /// Error that will cause an FTP reply code of 451 to be returned to the FTP client. It means
     /// the requested action was aborted due to a local error (internal storage back-end error) in
     /// processing.
     #[display(fmt = "451 Local error")]

--- a/src/storage/storage_backend.rs
+++ b/src/storage/storage_backend.rs
@@ -263,7 +263,7 @@ pub trait StorageBackend<User: UserDetail>: Send + Sync + Debug {
         P: AsRef<Path> + Send + Debug,
     {
         let mut reader = self.get(user, path, start_pos).await?;
-        Ok(tokio::io::copy(&mut reader, output).await?)
+        Ok(tokio::io::copy(&mut reader, output).await.map_err(Error::from)?)
     }
 
     /// Returns the content of the given file from offset start_pos.


### PR DESCRIPTION
Fixes #420 (omit multi line output in the logs)
Fixes part one of #81 (although was already handled mostly by Werner)

And lots of other things I came across:

Logging:
- Improved mappings from storage errors to FTP errors
- Moved many log messages from INFO to DEBUG level
- Introduced more user friendly log messages at INFO level
- Improved the log messages for all commands, making sure the log entries are clear and 'actionable'
- Introduced nice additional information on transfers (duration, size and transfer speed)
- Added some error logs when there were none

Metrics:
- Added a specific counter metric for data transfer commands, with a verdict on whether it's a server or client error
- Added in-flight count on transferred bytes (also labeled by command) so that we can calculate average transfer speed

Some bug fixes:
- LIST and NLST weren't returning replies correctly
- RETR was sending no Reply on the Control channel when there was no Data connection, causing the client to hang
- Bug with REST (restart) command not working correctly