### PR TITLE
Handle paginated results fixing issue #464

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### upcoming
+
+- [#465](https://github.com/bolcom/libunftp/pull/465) Handle paginated results for LIST fixing issue #464
+
 ### libunftp 0.18.9
 
 _tag: libunftp-0.18.9_

--- a/crates/unftp-sbe-gcs/src/response_body.rs
+++ b/crates/unftp-sbe-gcs/src/response_body.rs
@@ -11,6 +11,7 @@ use std::{iter::Extend, path::PathBuf};
 pub(crate) struct ResponseBody {
     items: Option<Vec<Item>>,
     prefixes: Option<Vec<String>>,
+    #[serde(rename = "nextPageToken")]
     next_page_token: Option<String>,
 }
 
@@ -103,6 +104,10 @@ impl ResponseBody {
             (_, _, Some(items)) => items.len() == 1 && items[0].name.ends_with('/'),
             (_, _, _) => false,
         }
+    }
+
+    pub(crate) fn next_token(&self) -> Option<String> {
+        self.next_page_token.as_ref().cloned()
     }
 }
 


### PR DESCRIPTION
GCS returns up to 1000 results, so 'directory' listings with more files turn up incomplete