### PR TITLE
Fix CWD on empty root

### DIFF
--- a/crates/unftp-sbe-gcs/src/gcs_client.rs
+++ b/crates/unftp-sbe-gcs/src/gcs_client.rs
@@ -203,7 +203,7 @@ impl GcsClient {
         self.http_get(uri).await
     }
 
-    fn path_is_root<P: AsRef<Path>>(path: &P) -> bool {
+    pub(crate) fn path_is_root<P: AsRef<Path>>(path: &P) -> bool {
         let path = path.as_ref();
         let relative_path = path.strip_prefix("/").unwrap_or(path);
 

--- a/crates/unftp-sbe-gcs/src/lib.rs
+++ b/crates/unftp-sbe-gcs/src/lib.rs
@@ -233,12 +233,16 @@ impl<User: UserDetail> StorageBackend<User> for CloudStorage {
     where
         P: AsRef<Path> + Send + Debug,
     {
-        let dir_empty_resp = self.gcs.dir_empty(path).await?;
-
-        if !dir_empty_resp.dir_exists() {
-            Err(Error::from(ErrorKind::PermanentDirectoryNotAvailable))
-        } else {
+        if GcsClient::path_is_root(&path) {
             Ok(())
+        } else {
+            let dir_empty_resp = self.gcs.dir_empty(path).await?;
+
+            if !dir_empty_resp.dir_exists() {
+                Err(Error::from(ErrorKind::PermanentDirectoryNotAvailable))
+            } else {
+                Ok(())
+            }
         }
     }
 }


### PR DESCRIPTION
When CWD'ing to / on an empty 'filesystem', GCS SBE was returning PermanentDirectoryNotAvailable.