### PR TITLE
Fix modified datetime formatting for `Fileinfo`

### DIFF
--- a/src/storage/storage_backend.rs
+++ b/src/storage/storage_backend.rs
@@ -4,7 +4,10 @@ use super::error::Error;
 use crate::auth::UserDetail;
 use crate::storage::ErrorKind;
 use async_trait::async_trait;
-use chrono::prelude::{DateTime, Utc};
+use chrono::{
+    prelude::{DateTime, Utc},
+    Datelike,
+};
 use libc;
 use md5::{Digest, Md5};
 use std::{
@@ -113,7 +116,15 @@ where
         let modified: String = self
             .metadata
             .modified()
-            .map(|x| DateTime::<Utc>::from(x).format("%b %d %H:%M").to_string())
+            .map(|modified| {
+                let modified = DateTime::<Utc>::from(modified);
+                let now = Utc::now();
+                if modified.year() == now.year() {
+                    modified.format("%b %d %H:%M").to_string()
+                } else {
+                    modified.format("%b %d %Y").to_string()
+                }
+            })
             .unwrap_or_else(|_| "--- -- --:--".to_string());
         let basename = self.path.as_ref().components().last();
         let path = match basename {


### PR DESCRIPTION
This PR changes the formatting of the last modification date within the `Display` implementation for `Fileinfo`, to make it more compatible the conventions of existing FTP clients.  

Currently, the last modification dates are always formatted as `%b %d %H:%M` (eg. `Mar 12 14:51`), even if the year of this last modification date isn't the current year.  
This can confuse lots of FTP clients that expect this date to be formatted as `%b %d %Y` if the year of the last modification is different from the current year, similar to how `ls` format these dates.  

This mismatch in date formatting doesn't only result in the parsed last modification dates to be different from the intended one, but it can also make it look like an impossible date to FTP clients, due to the existence of leap years.  

An example case of this is a file whose last modification date is `Feb 29 2016 10:42`.  
`libunftp` currently presents this date in the output of a `LIST` command as `Feb 29 10:42`.  
But some FTP clients interpret this date formatting as meaning `Feb 29 2023 10:42`, which is an impossible date, due to `2023` not being a leap year, and causing parsing errors.  

This PR therefore aims at fixing these cases.