### PR TITLE
Add more output to help command

### DIFF
--- a/src/server/controlchan/commands/help.rs
+++ b/src/server/controlchan/commands/help.rs
@@ -28,8 +28,7 @@ where
 {
     #[tracing_attributes::instrument]
     async fn handle(&self, _args: CommandContext<Storage, User>) -> Result<Reply, ControlChanError> {
-        let text = vec!["Help:", "Powered by libunftp"];
-        // TODO: Add useful information here like operating server type and app name.
+        let text = vec!["Help:", "Powered by libunftp", "View the docs at: https://unftp.rs/"];
         Ok(Reply::new_multiline(ReplyCode::HelpMessage, text))
     }
 }

--- a/src/server/controlchan/commands/help.rs
+++ b/src/server/controlchan/commands/help.rs
@@ -28,10 +28,11 @@ where
 {
     #[tracing_attributes::instrument]
     async fn handle(&self, _args: CommandContext<Storage, User>) -> Result<Reply, ControlChanError> {
-        let text = vec![
-            "Help:",
+        let text: Vec<String> = vec![
+            "Help:".to_string(),
             format!("Powered by libunftp: {}", env!("CARGO_PKG_VERSION")),
-            "View the docs at: https://unftp.rs/"];
+            "View the docs at: https://unftp.rs/".to_string(),
+        ];
         Ok(Reply::new_multiline(ReplyCode::HelpMessage, text))
     }
 }

--- a/src/server/controlchan/commands/help.rs
+++ b/src/server/controlchan/commands/help.rs
@@ -28,7 +28,10 @@ where
 {
     #[tracing_attributes::instrument]
     async fn handle(&self, _args: CommandContext<Storage, User>) -> Result<Reply, ControlChanError> {
-        let text = vec!["Help:", "Powered by libunftp", "View the docs at: https://unftp.rs/"];
+        let text = vec![
+            "Help:",
+            format!("Powered by libunftp: {}", env!("CARGO_PKG_VERSION")),
+            "View the docs at: https://unftp.rs/"];
         Ok(Reply::new_multiline(ReplyCode::HelpMessage, text))
     }
 }


### PR DESCRIPTION

Closes #40. Issuing an help command now also returns a link to the docs (https://unftp.rs/) & the libunftp version.