### PR TITLE
Capsicum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,8 @@ libc = "0.2"
 pretty_assertions = "1.4.0"
 tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
 unftp-sbe-fs = { path = "../libunftp/crates/unftp-sbe-fs"}
+
+
+[patch.crates-io]
+capsicum = { git = "https://github.com/asomers/capsicum-rs", rev = "24330ee"}
+casper-sys = { git = "https://github.com/asomers/capsicum-rs", rev = "24330ee"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ getrandom = "0.2.11"
 lazy_static = "1.4.0"
 md-5 = "0.10.6"
 moka = { version = "0.11.3", default-features = false, features = ["sync"] }
+nix = { version = "0.26.2", default-features = false, features = ["fs"] }
 prometheus = { version = "0.13.3", default-features = false }
 proxy-protocol = "0.5.0"
 rustls = "0.21.10"
@@ -47,7 +48,7 @@ rustls-pemfile = "1.0.4"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_info"] }
 slog-stdlog = "4.1.1"
 thiserror = "1.0.51"
-tokio = { version = "1.35.1", features = ["macros", "rt", "net", "sync", "io-util", "time"] }
+tokio = { version = "1.35.1", features = ["macros", "rt", "net", "process", "sync", "io-util", "time"] }
 tokio-rustls = "0.24.1"
 tokio-util = { version = "0.7.10", features = ["codec"] }
 tracing = { version = "0.1.40", default-features = false }

--- a/crates/unftp-auth-jsonfile/examples/jsonfile_auth.rs
+++ b/crates/unftp-auth-jsonfile/examples/jsonfile_auth.rs
@@ -8,7 +8,9 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let authenticator = JsonFileAuthenticator::from_file(String::from("credentials.json"))?;
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::with_fs(std::env::temp_dir()).authenticator(Arc::new(authenticator));
+    let server = libunftp::Server::with_fs(std::env::temp_dir()).authenticator(Arc::new(authenticator))
+        .build()
+        .unwrap();
 
     println!("Starting ftp server on {}", addr);
     let runtime = tokio::runtime::Builder::new_current_thread().enable_io().enable_time().build().unwrap();

--- a/crates/unftp-auth-jsonfile/examples/jsonfile_auth.rs
+++ b/crates/unftp-auth-jsonfile/examples/jsonfile_auth.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 use unftp_auth_jsonfile::JsonFileAuthenticator;
 use unftp_sbe_fs::ServerExt;
 
-pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main(flavor = "current_thread")]
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     pretty_env_logger::init();
 
     let authenticator = JsonFileAuthenticator::from_file(String::from("credentials.json"))?;
@@ -11,11 +12,11 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = libunftp::Server::with_fs(std::env::temp_dir())
         .authenticator(Arc::new(authenticator))
         .build()
+        .await
         .unwrap();
 
     println!("Starting ftp server on {}", addr);
-    let runtime = tokio::runtime::Builder::new_current_thread().enable_io().enable_time().build().unwrap();
-    runtime.block_on(server.listen(addr))?;
+    server.listen(addr).await?;
 
     Ok(())
 }

--- a/crates/unftp-auth-jsonfile/examples/jsonfile_auth.rs
+++ b/crates/unftp-auth-jsonfile/examples/jsonfile_auth.rs
@@ -8,7 +8,8 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let authenticator = JsonFileAuthenticator::from_file(String::from("credentials.json"))?;
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::with_fs(std::env::temp_dir()).authenticator(Arc::new(authenticator))
+    let server = libunftp::Server::with_fs(std::env::temp_dir())
+        .authenticator(Arc::new(authenticator))
         .build()
         .unwrap();
 

--- a/crates/unftp-auth-jsonfile/tests/main.rs
+++ b/crates/unftp-auth-jsonfile/tests/main.rs
@@ -15,7 +15,7 @@ async fn credentials_from_file_type_plain() {
     let path = input_file_path("cred.json".to_string());
 
     let json_auther = JsonFileAuthenticator::from_file(path).unwrap();
-    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap(), DefaultUser);
+    let _: DefaultUser = json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap();
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -23,7 +23,7 @@ async fn credentials_from_file_type_gzipped() {
     let path = input_file_path("cred.json.gz".to_string());
 
     let json_auther = JsonFileAuthenticator::from_file(path).unwrap();
-    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap(), DefaultUser);
+    let _: DefaultUser = json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap();
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -31,5 +31,5 @@ async fn credentials_from_file_type_gzipped_base64() {
     let path = input_file_path("cred.json.gz.b64".to_string());
 
     let json_auther = JsonFileAuthenticator::from_file(path).unwrap();
-    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap(), DefaultUser);
+    let _: DefaultUser = json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap();
 }

--- a/crates/unftp-auth-jsonfile/tests/main.rs
+++ b/crates/unftp-auth-jsonfile/tests/main.rs
@@ -15,7 +15,7 @@ async fn credentials_from_file_type_plain() {
     let path = input_file_path("cred.json".to_string());
 
     let json_auther = JsonFileAuthenticator::from_file(path).unwrap();
-    let _: DefaultUser = json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap();
+    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap(), DefaultUser);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -23,7 +23,7 @@ async fn credentials_from_file_type_gzipped() {
     let path = input_file_path("cred.json.gz".to_string());
 
     let json_auther = JsonFileAuthenticator::from_file(path).unwrap();
-    let _: DefaultUser = json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap();
+    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap(), DefaultUser);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -31,5 +31,5 @@ async fn credentials_from_file_type_gzipped_base64() {
     let path = input_file_path("cred.json.gz.b64".to_string());
 
     let json_auther = JsonFileAuthenticator::from_file(path).unwrap();
-    let _: DefaultUser = json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap();
+    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap(), DefaultUser);
 }

--- a/crates/unftp-auth-rest/examples/rest.rs
+++ b/crates/unftp-auth-rest/examples/rest.rs
@@ -1,10 +1,10 @@
 use std::env;
 use std::sync::Arc;
-use tokio::runtime::Builder as TokioBuilder;
 use unftp_auth_rest::{Builder, RestAuthenticator};
 use unftp_sbe_fs::ServerExt;
 
-pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main(flavor = "current_thread")]
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     pretty_env_logger::init();
 
     let _args: Vec<String> = env::args().collect();
@@ -24,10 +24,10 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = libunftp::Server::with_fs(std::env::temp_dir())
         .authenticator(Arc::new(authenticator))
         .build()
+        .await
         .unwrap();
 
     println!("Starting ftp server on {}", addr);
-    let runtime = TokioBuilder::new_current_thread().enable_io().enable_time().build()?;
-    runtime.block_on(server.listen(addr))?;
+    server.listen(addr).await?;
     Ok(())
 }

--- a/crates/unftp-auth-rest/examples/rest.rs
+++ b/crates/unftp-auth-rest/examples/rest.rs
@@ -21,7 +21,10 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::with_fs(std::env::temp_dir()).authenticator(Arc::new(authenticator));
+    let server = libunftp::Server::with_fs(std::env::temp_dir())
+        .authenticator(Arc::new(authenticator))
+        .build()
+        .unwrap();
 
     println!("Starting ftp server on {}", addr);
     let runtime = TokioBuilder::new_current_thread().enable_io().enable_time().build()?;

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -43,7 +43,7 @@ tempfile = "3.8.1"
 tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.18"
 getrandom = "0.2.11"
+unftp-auth-jsonfile = { path = "../unftp-auth-jsonfile" }
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 capsicum = "0.2.0"
-unftp-auth-jsonfile = { path = "../unftp-auth-jsonfile" }

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -43,3 +43,7 @@ tempfile = "3.8.1"
 tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.18"
 getrandom = "0.2.11"
+
+[target.'cfg(target_os = "freebsd")'.dev-dependencies]
+capsicum = "0.2.0"
+unftp-auth-jsonfile = { path = "../unftp-auth-jsonfile" }

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -48,4 +48,6 @@ tracing-subscriber = "0.3.18"
 getrandom = "0.2.11"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
-capsicum = "0.2.0"
+capsicum = { version = "0.3.0", features = ["casper"] }
+capsicum-net = { version = "0.1.0", features = ["tokio"], git = "https://github.com/asomers/capsicum-net", rev = "c6fc574" }
+

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -33,17 +33,19 @@ tracing-attributes = "0.1.27"
 
 [dev-dependencies]
 async_ftp = "6.0.0"
+async-trait = "0.1.73"
 more-asserts = "0.3.1"
 pretty_assertions = "1.4.0"
 pretty_env_logger = "0.5.0"
 rstest = "0.18.2"
+serde = { version = "1.0.188", features = ["derive"] }
+serde_json = "1.0.107"
 slog-async = "2.8.0"
 slog-term = "2.9.0"
 tempfile = "3.8.1"
 tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.18"
 getrandom = "0.2.11"
-unftp-auth-jsonfile = { path = "../unftp-auth-jsonfile" }
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 capsicum = "0.2.0"

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -21,7 +21,9 @@ readme = "README.md"
 [dependencies]
 async-trait = "0.1.75"
 cfg-if = "1.0"
+cap-std = "2.0"
 futures = { version = "0.3.29", default-features = false, features = ["std"] }
+lazy_static = "1.4.0"
 libunftp = { version="0.19.1", path="../../"}
 path_abs = "0.5.1"
 tokio = { version = "1.35.1", features = ["rt", "net", "sync", "io-util", "time", "fs"] }

--- a/crates/unftp-sbe-fs/examples/basic.rs
+++ b/crates/unftp-sbe-fs/examples/basic.rs
@@ -1,6 +1,6 @@
 use unftp_sbe_fs::ServerExt;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn main() {
     pretty_env_logger::init();
 

--- a/crates/unftp-sbe-fs/examples/basic.rs
+++ b/crates/unftp-sbe-fs/examples/basic.rs
@@ -5,10 +5,7 @@ pub async fn main() {
     pretty_env_logger::init();
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::with_fs(std::env::temp_dir())
-        .build()
-        .await
-        .unwrap();
+    let server = libunftp::Server::with_fs(std::env::temp_dir()).build().await.unwrap();
 
     println!("Starting ftp server on {}", addr);
     server.listen(addr).await.unwrap();

--- a/crates/unftp-sbe-fs/examples/basic.rs
+++ b/crates/unftp-sbe-fs/examples/basic.rs
@@ -5,7 +5,9 @@ pub async fn main() {
     pretty_env_logger::init();
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::with_fs(std::env::temp_dir());
+    let server = libunftp::Server::with_fs(std::env::temp_dir())
+        .build()
+        .unwrap();
 
     println!("Starting ftp server on {}", addr);
     server.listen(addr).await.unwrap();

--- a/crates/unftp-sbe-fs/examples/basic.rs
+++ b/crates/unftp-sbe-fs/examples/basic.rs
@@ -5,7 +5,10 @@ pub async fn main() {
     pretty_env_logger::init();
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::with_fs(std::env::temp_dir()).build().unwrap();
+    let server = libunftp::Server::with_fs(std::env::temp_dir())
+        .build()
+        .await
+        .unwrap();
 
     println!("Starting ftp server on {}", addr);
     server.listen(addr).await.unwrap();

--- a/crates/unftp-sbe-fs/examples/basic.rs
+++ b/crates/unftp-sbe-fs/examples/basic.rs
@@ -5,9 +5,7 @@ pub async fn main() {
     pretty_env_logger::init();
 
     let addr = "127.0.0.1:2121";
-    let server = libunftp::Server::with_fs(std::env::temp_dir())
-        .build()
-        .unwrap();
+    let server = libunftp::Server::with_fs(std::env::temp_dir()).build().unwrap();
 
     println!("Starting ftp server on {}", addr);
     server.listen(addr).await.unwrap();

--- a/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
@@ -1,0 +1,55 @@
+// vim: tw=80
+//! A libexec helper for cap-std.  It takes an int as $1 which is interpreted as
+//! a file descriptor for an already-connected an authenticated control socket.
+//! Do not invoke this program directly.  Rather, invoke it by examples/cap-ftpd
+#![cfg(target_os = "freebsd")]
+
+use std::{
+    env,
+    os::fd::{FromRawFd, RawFd},
+    process::exit,
+    sync::{Arc, Mutex}
+};
+
+use tokio::net::TcpStream;
+
+use libunftp::Server;
+use unftp_sbe_fs::Filesystem;
+use unftp_auth_jsonfile::{JsonFileAuthenticator, User};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    println!("Starting helper");
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 3 {
+        eprintln!("Usage: {} <AUTH_FILE> <FD>", args[0]);
+        exit(2);
+    }
+    let fd: RawFd = if let Ok(fd) =  args[2].parse() {
+        fd
+    } else {
+        eprintln!("Usage: {} <FD>\nFD must be numeric", args[0]);
+        exit(2)
+    };
+
+    let std_stream = unsafe {
+        std::net::TcpStream::from_raw_fd(fd)
+    };
+
+    let control_sock = TcpStream::from_std(std_stream).unwrap();
+
+    let auth = Arc::new(JsonFileAuthenticator::from_file(args[1].clone()).unwrap());
+    // XXX This would be a lot easier if the libunftp API allowed creating the
+    // storage just before calling service.
+    let storage = Mutex::new(Some(Filesystem::new(std::env::temp_dir())));
+    let sgen = Box::new(move || storage.lock().unwrap().take().unwrap());
+    let server: Server<Filesystem, User> = libunftp::ServerBuilder::with_authenticator(
+        sgen, auth)
+        .pasv_listener(control_sock.local_addr().unwrap().ip())
+        .await
+        .build()
+        .unwrap();
+    capsicum::enter().unwrap();
+    server.service(control_sock).await.unwrap()
+}

--- a/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
@@ -2,14 +2,14 @@
 //! A libexec helper for cap-std.  It takes an int as $1 which is interpreted as
 //! a file descriptor for an already-connected an authenticated control socket.
 //! Do not invoke this program directly.  Rather, invoke it by examples/cap-ftpd
-#![cfg(target_os = "freebsd")]
-
 use std::{
     env,
     os::fd::{FromRawFd, RawFd},
     process::exit,
     sync::{Arc, Mutex},
 };
+
+use cfg_if::cfg_if;
 
 use tokio::net::TcpStream;
 
@@ -47,6 +47,10 @@ async fn main() {
         .await
         .build()
         .unwrap();
-    capsicum::enter().unwrap();
+    cfg_if! {
+        if #[cfg(target_os = "freebsd")] {
+            capsicum::enter().unwrap();
+        }
+    }
     server.service(control_sock).await.unwrap()
 }

--- a/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
@@ -8,14 +8,14 @@ use std::{
     env,
     os::fd::{FromRawFd, RawFd},
     process::exit,
-    sync::{Arc, Mutex}
+    sync::{Arc, Mutex},
 };
 
 use tokio::net::TcpStream;
 
 use libunftp::Server;
-use unftp_sbe_fs::Filesystem;
 use unftp_auth_jsonfile::{JsonFileAuthenticator, User};
+use unftp_sbe_fs::Filesystem;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -26,16 +26,14 @@ async fn main() {
         eprintln!("Usage: {} <AUTH_FILE> <FD>", args[0]);
         exit(2);
     }
-    let fd: RawFd = if let Ok(fd) =  args[2].parse() {
+    let fd: RawFd = if let Ok(fd) = args[2].parse() {
         fd
     } else {
         eprintln!("Usage: {} <FD>\nFD must be numeric", args[0]);
         exit(2)
     };
 
-    let std_stream = unsafe {
-        std::net::TcpStream::from_raw_fd(fd)
-    };
+    let std_stream = unsafe { std::net::TcpStream::from_raw_fd(fd) };
 
     let control_sock = TcpStream::from_std(std_stream).unwrap();
 
@@ -44,8 +42,7 @@ async fn main() {
     // storage just before calling service.
     let storage = Mutex::new(Some(Filesystem::new(std::env::temp_dir())));
     let sgen = Box::new(move || storage.lock().unwrap().take().unwrap());
-    let server: Server<Filesystem, User> = libunftp::ServerBuilder::with_authenticator(
-        sgen, auth)
+    let server: Server<Filesystem, User> = libunftp::ServerBuilder::with_authenticator(sgen, auth)
         .pasv_listener(control_sock.local_addr().unwrap().ip())
         .await
         .build()

--- a/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
@@ -200,8 +200,8 @@ async fn main() {
     let sgen = Box::new(move || storage.lock().unwrap().take().unwrap());
     let server: Server<Filesystem, User> = libunftp::ServerBuilder::with_authenticator(sgen, auth)
         .pasv_listener(control_sock.local_addr().unwrap().ip())
-        .await
         .build()
+        .await
         .unwrap();
     cfg_if! {
         if #[cfg(target_os = "freebsd")] {

--- a/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
@@ -13,8 +13,165 @@ use cfg_if::cfg_if;
 use tokio::net::TcpStream;
 
 use libunftp::Server;
-use unftp_auth_jsonfile::{JsonFileAuthenticator, User};
 use unftp_sbe_fs::Filesystem;
+
+mod auth {
+    use std::{
+        collections::HashMap,
+        fmt, fs,
+        io::Read,
+        path::{Path, PathBuf},
+        time::Duration,
+    };
+
+    use async_trait::async_trait;
+    use libunftp::auth::{AuthenticationError, Authenticator, DefaultUser, UserDetail};
+    use serde::Deserialize;
+    use tokio::time::sleep;
+
+    #[derive(Debug)]
+    pub struct User {
+        username: String,
+        home: Option<PathBuf>,
+    }
+
+    #[derive(Deserialize, Clone, Debug)]
+    #[serde(untagged)]
+    enum Credentials {
+        Plaintext {
+            username: String,
+            password: Option<String>,
+            home: Option<PathBuf>,
+        },
+    }
+
+    #[derive(Clone, Debug)]
+    struct UserCreds {
+        pub password: Option<String>,
+        pub home: Option<PathBuf>,
+    }
+
+    impl User {
+        fn new(username: &str, home: &Option<PathBuf>) -> Self {
+            User {
+                username: username.to_owned(),
+                home: home.clone(),
+            }
+        }
+    }
+
+    impl UserDetail for User {
+        fn home(&self) -> Option<&Path> {
+            match &self.home {
+                None => None,
+                Some(p) => Some(p.as_path()),
+            }
+        }
+    }
+
+    impl fmt::Display for User {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.username.as_str())
+        }
+    }
+
+    /// This structure implements the libunftp `Authenticator` trait
+    #[derive(Clone, Debug)]
+    pub struct JsonFileAuthenticator {
+        credentials_map: HashMap<String, UserCreds>,
+    }
+
+    impl JsonFileAuthenticator {
+        /// Initialize a new [`JsonFileAuthenticator`] from file.
+        pub fn from_file<P: AsRef<Path>>(filename: P) -> Result<Self, Box<dyn std::error::Error>> {
+            let mut f = fs::File::open(&filename)?;
+
+            let mut json = String::new();
+            f.read_to_string(&mut json)?;
+
+            Self::from_json(json)
+        }
+
+        /// Initialize a new [`JsonFileAuthenticator`] from json string.
+        pub fn from_json<T: Into<String>>(json: T) -> Result<Self, Box<dyn std::error::Error>> {
+            let credentials_list: Vec<Credentials> = serde_json::from_str::<Vec<Credentials>>(&json.into())?;
+            let map: Result<HashMap<String, UserCreds>, _> = credentials_list.into_iter().map(Self::list_entry_to_map_entry).collect();
+            Ok(JsonFileAuthenticator { credentials_map: map? })
+        }
+
+        fn list_entry_to_map_entry(user_info: Credentials) -> Result<(String, UserCreds), Box<dyn std::error::Error>> {
+            let map_entry = match user_info {
+                Credentials::Plaintext { username, password, home } => (username.clone(), UserCreds { password, home }),
+            };
+            Ok(map_entry)
+        }
+
+        fn check_password(given_password: &str, actual_password: &Option<String>) -> Result<(), ()> {
+            if let Some(pwd) = actual_password {
+                if pwd == given_password {
+                    Ok(())
+                } else {
+                    Err(())
+                }
+            } else {
+                Err(())
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Authenticator<User> for JsonFileAuthenticator {
+        #[tracing_attributes::instrument]
+        async fn authenticate(&self, username: &str, creds: &libunftp::auth::Credentials) -> Result<User, AuthenticationError> {
+            let res = if let Some(actual_creds) = self.credentials_map.get(username) {
+                let pass_check_result = match &creds.password {
+                    Some(ref given_password) => {
+                        if Self::check_password(given_password, &actual_creds.password).is_ok() {
+                            Some(Ok(User::new(username, &actual_creds.home)))
+                        } else {
+                            Some(Err(AuthenticationError::BadPassword))
+                        }
+                    }
+                    None => None,
+                };
+
+                match pass_check_result {
+                    None => Err(AuthenticationError::BadPassword),
+                    Some(pass_res) => {
+                        if pass_res.is_ok() {
+                            Ok(User::new(username, &actual_creds.home))
+                        } else {
+                            pass_res
+                        }
+                    }
+                }
+            } else {
+                Err(AuthenticationError::BadUser)
+            };
+
+            if res.is_err() {
+                sleep(Duration::from_millis(1500)).await;
+            }
+
+            res
+        }
+
+        fn name(&self) -> &str {
+            std::any::type_name::<Self>()
+        }
+    }
+
+    #[async_trait]
+    impl Authenticator<DefaultUser> for JsonFileAuthenticator {
+        #[tracing_attributes::instrument]
+        async fn authenticate(&self, username: &str, creds: &libunftp::auth::Credentials) -> Result<DefaultUser, AuthenticationError> {
+            let _: User = self.authenticate(username, creds).await?;
+            Ok(DefaultUser {})
+        }
+    }
+}
+
+use auth::{JsonFileAuthenticator, User};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {

--- a/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
@@ -1,4 +1,3 @@
-// vim: tw=80
 //! A libexec helper for cap-std.  It takes an int as $1 which is interpreted as
 //! a file descriptor for an already-connected an authenticated control socket.
 //! Do not invoke this program directly.  Rather, invoke it by examples/cap-ftpd

--- a/crates/unftp-sbe-fs/examples/cap-ftpd.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd.rs
@@ -1,0 +1,30 @@
+//! A server that jails each connected session with Capsicum.
+#![cfg(target_os = "freebsd")]
+
+use std::{ffi::OsString, str::FromStr, path::Path};
+
+use unftp_sbe_fs::ServerExt;
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn main() {
+    let addr = "127.0.0.1:2121";
+
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() != 2 {
+        eprintln!("Usage: {} <AUTH_FILE.json>", args[0]);
+        std::process::exit(2);
+    }
+    let auth_file = &args[1];
+
+    let args: Vec<String> = std::env::args().collect();
+    let helper = Path::new(&args[0]).parent().unwrap().join("cap-ftpd-worker");
+    let helper_args = vec![OsString::from_str(auth_file).unwrap()];
+    let server = libunftp::Server::with_fs(std::env::temp_dir())
+        .connection_helper(helper.into(), helper_args)
+        .build()
+        .unwrap();
+
+    println!("Starting ftp server on {}", addr);
+    server.listen(addr).await.unwrap();
+}

--- a/crates/unftp-sbe-fs/examples/cap-ftpd.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd.rs
@@ -1,6 +1,4 @@
 //! A server that jails each connected session with Capsicum.
-#![cfg(target_os = "freebsd")]
-
 use std::{ffi::OsString, path::Path, str::FromStr};
 
 use unftp_sbe_fs::ServerExt;

--- a/crates/unftp-sbe-fs/examples/cap-ftpd.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd.rs
@@ -21,6 +21,7 @@ pub async fn main() {
     let server = libunftp::Server::with_fs(std::env::temp_dir())
         .connection_helper(helper.into(), helper_args)
         .build()
+        .await
         .unwrap();
 
     println!("Starting ftp server on {}", addr);

--- a/crates/unftp-sbe-fs/examples/cap-ftpd.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd.rs
@@ -1,7 +1,7 @@
 //! A server that jails each connected session with Capsicum.
 #![cfg(target_os = "freebsd")]
 
-use std::{ffi::OsString, str::FromStr, path::Path};
+use std::{ffi::OsString, path::Path, str::FromStr};
 
 use unftp_sbe_fs::ServerExt;
 

--- a/crates/unftp-sbe-fs/examples/proxyprotocol.rs
+++ b/crates/unftp-sbe-fs/examples/proxyprotocol.rs
@@ -7,7 +7,9 @@ pub async fn main() {
     let addr = "127.0.0.1:2121";
     let server = libunftp::Server::with_fs(std::env::temp_dir())
         .proxy_protocol_mode(2121)
-        .passive_ports(5000..5005);
+        .passive_ports(5000..5005)
+        .build()
+        .unwrap();
 
     println!("Starting ftp server with proxy protocol on {}", addr);
     server.listen(addr).await.unwrap();

--- a/crates/unftp-sbe-fs/examples/proxyprotocol.rs
+++ b/crates/unftp-sbe-fs/examples/proxyprotocol.rs
@@ -9,6 +9,7 @@ pub async fn main() {
         .proxy_protocol_mode(2121)
         .passive_ports(5000..5005)
         .build()
+        .await
         .unwrap();
 
     println!("Starting ftp server with proxy protocol on {}", addr);

--- a/crates/unftp-sbe-fs/src/cap_fs.rs
+++ b/crates/unftp-sbe-fs/src/cap_fs.rs
@@ -1,0 +1,125 @@
+//! A capabilities-friendly workalike of tokio::fs
+// Most of these functions are copied almost verbatim from tokio::fs, but with the std parts
+// replaced by cap_std.
+
+use std::{
+    io,
+    path::Path,
+    sync::Arc
+};
+
+use tokio::{
+    sync::mpsc,
+    task::spawn_blocking
+};
+use tokio_stream::wrappers::ReceiverStream;
+
+/// Exact copy of tokio::fs::asyncify
+async fn asyncify<F, T>(f: F) -> io::Result<T>
+where
+    F: FnOnce() -> io::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match spawn_blocking(f).await {
+        Ok(res) => res,
+        Err(_) => Err(io::Error::new(
+            io::ErrorKind::Other,
+            "background task failed",
+        )),
+    }
+}
+
+/// Create a new directory somewhere under this one
+pub async fn create_dir<P: AsRef<Path>>(root: Arc<cap_std::fs::Dir>, path: P) -> io::Result<()> {
+    let path = path.as_ref().to_owned();
+    asyncify(move || root.create_dir(path)).await
+}
+
+pub async fn open<P: AsRef<Path>>(root: Arc<cap_std::fs::Dir>, path: P) -> io::Result<cap_std::fs::File> {
+    let path = path.as_ref().to_owned();
+    asyncify(move || root.open(path)).await
+}
+
+pub async fn open_with<P: AsRef<Path>>(
+    root: Arc<cap_std::fs::Dir>,
+    path: P,
+    options: cap_std::fs::OpenOptions
+) -> io::Result<cap_std::fs::File>
+{
+    let path = path.as_ref().to_owned();
+    asyncify(move || root.open_with(path, &options)).await
+}
+
+/// Returns a stream over the entries within a directory.
+///
+/// This is a capabilties-based, async version of [`std::fs::read_dir`](std::fs::read_dir)
+///
+/// This operation is implemented by running the equivalent blocking
+/// operation on a separate thread pool using [`spawn_blocking`].
+///
+/// [`spawn_blocking`]: tokio::task::spawn_blocking
+pub fn read_dir(root: Arc<cap_std::fs::Dir>, path: impl AsRef<Path>)
+    -> ReceiverStream<io::Result<cap_std::fs::DirEntry>>
+{
+    const CHUNKSIZE: usize = 32;
+
+    let path = path.as_ref().to_owned();
+    let (tx, rx) = mpsc::channel(CHUNKSIZE);
+    tokio::spawn(spawn_blocking(move || {
+        let r = root.read_dir(path);
+        match r {
+            Ok(rd) => {
+                for entry in rd {
+                    tx.blocking_send(entry).unwrap()
+                }
+            },
+            Err(e) => {
+                tx.blocking_send(Err(e)).unwrap()
+            }
+        }
+    }));
+    ReceiverStream::new(rx)
+}
+
+/// Removes an existing, empty directory.
+///
+/// This is a capability-based, async version of
+/// [`std::fs::remove_dir`](std::fs::remove_dir)
+pub async fn remove_dir(root: Arc<cap_std::fs::Dir>, path: impl AsRef<Path>) -> io::Result<()> {
+    let path = path.as_ref().to_owned();
+    asyncify(move || root.remove_dir(path)).await
+}
+
+/// Removes a file from the filesystem.
+///
+/// Note that there is no guarantee that the file is immediately deleted (e.g.
+/// depending on platform, other open file descriptors may prevent immediate
+/// removal).
+///
+/// This is a capabilities-based, async version of [`std::fs::remove_file`][std]
+///
+/// [std]: std::fs::remove_file
+pub async fn remove_file(root: Arc<cap_std::fs::Dir>, path: impl AsRef<Path>) -> io::Result<()> {
+    let path = path.as_ref().to_owned();
+    asyncify(move || root.remove_file(path)).await
+}
+
+/// Renames a file or directory to a new name, replacing the original file if
+/// `to` already exists.
+///
+/// This will not work if the new name is on a different mount point.
+///
+/// This is a capabilities-based async version of
+/// [`std::fs::rename`](std::fs::rename)
+pub async fn rename(root: Arc<cap_std::fs::Dir>, from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
+    let from = from.as_ref().to_owned();
+    let to = to.as_ref().to_owned();
+
+    asyncify(move || root.rename(from, &root, to)).await
+}
+
+/// Queries the file system metadata for a path.
+pub async fn symlink_metadata<P: AsRef<Path>>(root: Arc<cap_std::fs::Dir>, path: P) ->io::Result<cap_std::fs::Metadata> {
+    let path = path.as_ref().to_owned();
+    asyncify(move || root.symlink_metadata(path)).await
+}

--- a/crates/unftp-sbe-fs/src/cap_fs.rs
+++ b/crates/unftp-sbe-fs/src/cap_fs.rs
@@ -2,16 +2,9 @@
 // Most of these functions are copied almost verbatim from tokio::fs, but with the std parts
 // replaced by cap_std.
 
-use std::{
-    io,
-    path::Path,
-    sync::Arc
-};
+use std::{io, path::Path, sync::Arc};
 
-use tokio::{
-    sync::mpsc,
-    task::spawn_blocking
-};
+use tokio::{sync::mpsc, task::spawn_blocking};
 use tokio_stream::wrappers::ReceiverStream;
 
 /// Exact copy of tokio::fs::asyncify
@@ -22,10 +15,7 @@ where
 {
     match spawn_blocking(f).await {
         Ok(res) => res,
-        Err(_) => Err(io::Error::new(
-            io::ErrorKind::Other,
-            "background task failed",
-        )),
+        Err(_) => Err(io::Error::new(io::ErrorKind::Other, "background task failed")),
     }
 }
 
@@ -40,12 +30,7 @@ pub async fn open<P: AsRef<Path>>(root: Arc<cap_std::fs::Dir>, path: P) -> io::R
     asyncify(move || root.open(path)).await
 }
 
-pub async fn open_with<P: AsRef<Path>>(
-    root: Arc<cap_std::fs::Dir>,
-    path: P,
-    options: cap_std::fs::OpenOptions
-) -> io::Result<cap_std::fs::File>
-{
+pub async fn open_with<P: AsRef<Path>>(root: Arc<cap_std::fs::Dir>, path: P, options: cap_std::fs::OpenOptions) -> io::Result<cap_std::fs::File> {
     let path = path.as_ref().to_owned();
     asyncify(move || root.open_with(path, &options)).await
 }
@@ -58,9 +43,7 @@ pub async fn open_with<P: AsRef<Path>>(
 /// operation on a separate thread pool using [`spawn_blocking`].
 ///
 /// [`spawn_blocking`]: tokio::task::spawn_blocking
-pub fn read_dir(root: Arc<cap_std::fs::Dir>, path: impl AsRef<Path>)
-    -> ReceiverStream<io::Result<cap_std::fs::DirEntry>>
-{
+pub fn read_dir(root: Arc<cap_std::fs::Dir>, path: impl AsRef<Path>) -> ReceiverStream<io::Result<cap_std::fs::DirEntry>> {
     const CHUNKSIZE: usize = 32;
 
     let path = path.as_ref().to_owned();
@@ -72,10 +55,8 @@ pub fn read_dir(root: Arc<cap_std::fs::Dir>, path: impl AsRef<Path>)
                 for entry in rd {
                     tx.blocking_send(entry).unwrap()
                 }
-            },
-            Err(e) => {
-                tx.blocking_send(Err(e)).unwrap()
             }
+            Err(e) => tx.blocking_send(Err(e)).unwrap(),
         }
     }));
     ReceiverStream::new(rx)
@@ -119,7 +100,7 @@ pub async fn rename(root: Arc<cap_std::fs::Dir>, from: impl AsRef<Path>, to: imp
 }
 
 /// Queries the file system metadata for a path.
-pub async fn symlink_metadata<P: AsRef<Path>>(root: Arc<cap_std::fs::Dir>, path: P) ->io::Result<cap_std::fs::Metadata> {
+pub async fn symlink_metadata<P: AsRef<Path>>(root: Arc<cap_std::fs::Dir>, path: P) -> io::Result<cap_std::fs::Metadata> {
     let path = path.as_ref().to_owned();
     asyncify(move || root.symlink_metadata(path)).await
 }

--- a/crates/unftp-sbe-fs/src/ext.rs
+++ b/crates/unftp-sbe-fs/src/ext.rs
@@ -1,6 +1,6 @@
 use crate::Filesystem;
 use libunftp::auth::DefaultUser;
-use libunftp::Server;
+use libunftp::{Server, ServerBuilder};
 use std::path::PathBuf;
 
 /// Extension trait purely for construction convenience.
@@ -15,9 +15,9 @@ pub trait ServerExt {
     ///
     /// let server = Server::with_fs("/srv/ftp");
     /// ```
-    fn with_fs<P: Into<PathBuf> + Send + 'static>(path: P) -> Server<Filesystem, DefaultUser> {
+    fn with_fs<P: Into<PathBuf> + Send + 'static>(path: P) -> ServerBuilder<Filesystem, DefaultUser> {
         let p = path.into();
-        libunftp::Server::new(Box::new(move || {
+        libunftp::ServerBuilder::new(Box::new(move || {
             let p = &p.clone();
             Filesystem::new(p)
         }))

--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -13,6 +13,7 @@
 //!         .greeting("Welcome to my FTP server")
 //!         .passive_ports(50000..65535)
 //!         .build()
+//!         .await
 //!         .unwrap();
 //!
 //!     server.listen("127.0.0.1:2121").await;

--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -91,7 +91,7 @@ impl Filesystem {
 impl<User: UserDetail> StorageBackend<User> for Filesystem {
     type Metadata = Meta;
 
-    fn enter<U: UserDetail>(&mut self, user_detail: &U) -> io::Result<()> {
+    fn enter(&mut self, user_detail: &User) -> io::Result<()> {
         if let Some(path) = user_detail.home() {
             let relpath = match path.strip_prefix(self.root.as_path()) {
                 Ok(r) => r,

--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -31,7 +31,6 @@ use futures::{future::TryFutureExt, stream::TryStreamExt};
 use lazy_static::lazy_static;
 use libunftp::auth::UserDetail;
 use libunftp::storage::{Error, ErrorKind, Fileinfo, Metadata, Result, StorageBackend};
-use tokio::io::AsyncSeekExt;
 use std::{
     fmt::Debug,
     io,
@@ -39,6 +38,7 @@ use std::{
     sync::Arc,
     time::SystemTime,
 };
+use tokio::io::AsyncSeekExt;
 
 #[cfg(target_os = "unix")]
 use std::os::unix::fs::MetadataExt;

--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -20,23 +20,27 @@
 mod ext;
 pub use ext::ServerExt;
 
+mod cap_fs;
+
 use async_trait::async_trait;
 use cfg_if::cfg_if;
+use futures::{
+    future::TryFutureExt,
+    stream::TryStreamExt
+};
+use lazy_static::lazy_static;
 use libunftp::auth::UserDetail;
 use libunftp::storage::{Error, ErrorKind, Fileinfo, Metadata, Result, StorageBackend};
 use std::{
     fmt::Debug,
+    io::Seek,
     path::{Path, PathBuf},
+    sync::Arc,
     time::SystemTime,
 };
 
-cfg_if! {
-    if #[cfg(target_os = "linux")] {
-        use std::os::linux::fs::MetadataExt;
-    } else if #[cfg(target_os = "unix")] {
-        use std::os::unix::fs::MetadataExt;
-    }
-}
+#[cfg(target_os = "unix")]
+use std::os::unix::fs::MetadataExt;
 
 /// The Filesystem struct is an implementation of the StorageBackend trait that keeps its files
 /// inside a specific root directory on local disk.
@@ -44,23 +48,29 @@ cfg_if! {
 /// [`Filesystem`]: ./trait.Filesystem.html
 #[derive(Debug)]
 pub struct Filesystem {
-    root: PathBuf,
+    // The Arc is necessary so we can pass it to async closures.  Which is of dubious utility
+    // anyway, since most of those closures execute functions like fstatfs that are faster than the
+    // cost of switching a thread.
+    root_fd: Arc<cap_std::fs::Dir>
 }
 
 #[derive(Debug)]
 pub struct Meta {
-    inner: std::fs::Metadata,
+    inner: cap_std::fs::Metadata,
 }
 
-/// Returns the canonical path corresponding to the input path, sequences like '../' resolved.
-///
-/// I may decide to make this part of just the Filesystem implementation, because strictly speaking
-/// '../' is only special on the context of a filesystem. Then again, FTP does kind of imply a
-/// filesystem... hmm...
-fn canonicalize<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
-    use path_abs::PathAbs;
-    let p = PathAbs::new(path).map_err(|_| Error::from(ErrorKind::FileNameNotAllowedError))?;
-    Ok(p.as_path().to_path_buf())
+/// Strip the "/" prefix, if any, from a path.  Suitable for preprocessing the input pathnames
+/// supplied by the FTP client.
+fn strip_prefixes(path: &Path) -> &Path {
+    lazy_static! {
+        static ref DOT: PathBuf = PathBuf::from(".");
+        static ref SLASH: PathBuf = PathBuf::from("/");
+    }
+    if path == SLASH.as_path() {
+        DOT.as_path()
+    } else {
+        path.strip_prefix("/").unwrap_or(path)
+    }
 }
 
 impl Filesystem {
@@ -69,31 +79,10 @@ impl Filesystem {
     /// asks for `hello.txt`, the server will send it `/srv/ftp/hello.txt`.
     pub fn new<P: Into<PathBuf>>(root: P) -> Self {
         let path = root.into();
+        let aa = cap_std::ambient_authority();
+        let root_fd = Arc::new(cap_std::fs::Dir::open_ambient_dir(&path, aa).unwrap());
         Filesystem {
-            root: canonicalize(&path).unwrap_or(path),
-        }
-    }
-
-    /// Returns the full, absolute and canonical path corresponding to the (relative to FTP root)
-    /// input path, resolving symlinks and sequences like '../'.
-    async fn full_path<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf> {
-        // `path.join(other_path)` replaces `path` with `other_path` if `other_path` is absolute,
-        // so we have to check for it.
-        let path = path.as_ref();
-        let full_path = if path.starts_with("/") {
-            self.root.join(path.strip_prefix("/").unwrap())
-        } else {
-            self.root.join(path)
-        };
-
-        let real_full_path = tokio::task::spawn_blocking(move || canonicalize(full_path))
-            .await
-            .map_err(|e| Error::new(ErrorKind::LocalError, e))??;
-
-        if real_full_path.starts_with(&self.root) {
-            Ok(real_full_path)
-        } else {
-            Err(Error::from(ErrorKind::PermanentFileNotAvailable))
+            root_fd
         }
     }
 }
@@ -108,9 +97,8 @@ impl<User: UserDetail> StorageBackend<User> for Filesystem {
 
     #[tracing_attributes::instrument]
     async fn metadata<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<Self::Metadata> {
-        let full_path = self.full_path(path).await?;
-
-        let fs_meta = tokio::fs::symlink_metadata(full_path)
+        let path = path.as_ref().to_owned();
+        let fs_meta = cap_fs::symlink_metadata(self.root_fd.clone(), &path)
             .await
             .map_err(|_| Error::from(ErrorKind::PermanentFileNotAvailable))?;
         Ok(Meta { inner: fs_meta })
@@ -123,35 +111,31 @@ impl<User: UserDetail> StorageBackend<User> for Filesystem {
         P: AsRef<Path> + Send + Debug,
         <Self as StorageBackend<User>>::Metadata: Metadata,
     {
-        let full_path: PathBuf = self.full_path(path).await?;
+        let path = strip_prefixes(path.as_ref());
 
-        let prefix: PathBuf = self.root.clone();
-
-        let mut rd: tokio::fs::ReadDir = tokio::fs::read_dir(full_path).await?;
-
-        let mut fis: Vec<Fileinfo<std::path::PathBuf, Self::Metadata>> = vec![];
-        while let Ok(Some(dir_entry)) = rd.next_entry().await {
-            let prefix = prefix.clone();
-            let path = dir_entry.path();
-            let relpath = path.strip_prefix(prefix).unwrap();
-            let relpath: PathBuf = std::path::PathBuf::from(relpath);
-            let metadata = tokio::fs::symlink_metadata(dir_entry.path()).await?;
-            let meta: Self::Metadata = Meta { inner: metadata };
-            fis.push(Fileinfo { path: relpath, metadata: meta })
-        }
+        let fis: Vec<Fileinfo<std::path::PathBuf, Self::Metadata>> =
+            cap_fs::read_dir(self.root_fd.clone(), path)
+            .and_then(|dirent| {
+                let entry_path: PathBuf = dirent.file_name().into();
+                cap_fs::symlink_metadata(self.root_fd.clone(), path.join(entry_path.clone()))
+                    .map_ok(move |meta| {
+                        let metadata = Meta { inner: meta };
+                        Fileinfo{ path: entry_path, metadata}
+                    })
+            }).try_collect::<Vec<_>>()
+            .await?;
 
         Ok(fis)
     }
 
     //#[tracing_attributes::instrument]
     async fn get<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P, start_pos: u64) -> Result<Box<dyn tokio::io::AsyncRead + Send + Sync + Unpin>> {
-        use tokio::io::AsyncSeekExt;
-
-        let full_path = self.full_path(path).await?;
-        let mut file = tokio::fs::File::open(full_path).await?;
+        let path = path.as_ref().strip_prefix("/").unwrap_or(path.as_ref());
+        let mut file = cap_fs::open(self.root_fd.clone(), path).await?;
         if start_pos > 0 {
-            file.seek(std::io::SeekFrom::Start(start_pos)).await?;
+            file.seek(std::io::SeekFrom::Start(start_pos))?;
         }
+        let file = tokio::fs::File::from_std(file.into_std());
 
         Ok(Box::new(tokio::io::BufReader::with_capacity(4096, file)) as Box<dyn tokio::io::AsyncRead + Send + Sync + Unpin>)
     }
@@ -163,18 +147,16 @@ impl<User: UserDetail> StorageBackend<User> for Filesystem {
         path: P,
         start_pos: u64,
     ) -> Result<u64> {
-        use tokio::io::AsyncSeekExt;
         // TODO: Add permission checks
-        let path = path.as_ref();
-        let full_path = if path.starts_with("/") {
-            self.root.join(path.strip_prefix("/").unwrap())
-        } else {
-            self.root.join(path)
-        };
 
-        let mut file = tokio::fs::OpenOptions::new().write(true).create(true).open(full_path).await?;
-        file.set_len(start_pos).await?;
-        file.seek(std::io::SeekFrom::Start(start_pos)).await?;
+        let path = path.as_ref().strip_prefix("/").unwrap_or(path.as_ref());
+        let mut oo = cap_std::fs::OpenOptions::new();
+        oo.write(true).create(true);
+        let mut file = cap_fs::open_with(self.root_fd.clone(), path, oo).await?;
+        // XXX set_len ideally should go in a spawn_blocking
+        file.set_len(start_pos)?;
+        file.seek(std::io::SeekFrom::Start(start_pos))?;
+        let file = tokio::fs::File::from_std(file.into_std());
 
         let mut reader = tokio::io::BufReader::with_capacity(4096, bytes);
         let mut writer = tokio::io::BufWriter::with_capacity(4096, file);
@@ -185,35 +167,34 @@ impl<User: UserDetail> StorageBackend<User> for Filesystem {
 
     #[tracing_attributes::instrument]
     async fn del<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<()> {
-        let full_path = self.full_path(path).await?;
-        tokio::fs::remove_file(full_path).await.map_err(|error: std::io::Error| error.into())
+        let path = path.as_ref().strip_prefix("/").unwrap_or(path.as_ref());
+        cap_fs::remove_file(self.root_fd.clone(), path).await.map_err(|error: std::io::Error| error.into())
     }
 
     #[tracing_attributes::instrument]
     async fn rmd<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<()> {
-        let full_path = self.full_path(path).await?;
-        tokio::fs::remove_dir(full_path).await.map_err(|error: std::io::Error| error.into())
+        let path = path.as_ref().strip_prefix("/").unwrap_or(path.as_ref());
+        cap_fs::remove_dir(self.root_fd.clone(), path).await.map_err(|error: std::io::Error| error.into())
     }
 
     #[tracing_attributes::instrument]
     async fn mkd<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<()> {
-        tokio::fs::create_dir(self.full_path(path).await?)
+        let path = path.as_ref().strip_prefix("/").unwrap_or(path.as_ref());
+        cap_fs::create_dir(self.root_fd.clone(), path)
             .await
             .map_err(|error: std::io::Error| error.into())
     }
 
     #[tracing_attributes::instrument]
     async fn rename<P: AsRef<Path> + Send + Debug>(&self, _user: &User, from: P, to: P) -> Result<()> {
-        let from = self.full_path(from).await?;
-        let to = self.full_path(to).await?;
+        let from = from.as_ref().strip_prefix("/").unwrap_or(from.as_ref());
+        let to = to.as_ref().strip_prefix("/").unwrap_or(to.as_ref());
 
-        let from_rename = from.clone();
-
-        let r = tokio::fs::symlink_metadata(from).await;
+        let r = cap_fs::symlink_metadata(self.root_fd.clone(), &from).await;
         match r {
             Ok(metadata) => {
                 if metadata.is_file() || metadata.is_dir() {
-                    let r = tokio::fs::rename(from_rename, to).await;
+                    let r = cap_fs::rename(self.root_fd.clone(), from, to).await;
                     match r {
                         Ok(_) => Ok(()),
                         Err(e) => Err(Error::new(ErrorKind::PermanentFileNotAvailable, e)),
@@ -227,9 +208,8 @@ impl<User: UserDetail> StorageBackend<User> for Filesystem {
     }
 
     #[tracing_attributes::instrument]
-    async fn cwd<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<()> {
-        let full_path = self.full_path(path).await?;
-        tokio::fs::read_dir(full_path).await.map_err(|error: std::io::Error| error.into()).map(|_| ())
+    async fn cwd<P: AsRef<Path> + Send + Debug>(&self, user: &User, path: P) -> Result<()> {
+        self.list(user, path).await.map(drop)
     }
 }
 
@@ -251,15 +231,12 @@ impl Metadata for Meta {
     }
 
     fn modified(&self) -> Result<SystemTime> {
-        self.inner.modified().map_err(|e| e.into())
+        self.inner.modified().map(cap_std::time::SystemTime::into_std).map_err(|e| e.into())
     }
 
     fn gid(&self) -> u32 {
         cfg_if! {
-            if #[cfg(target_os = "linux")] {
-                self.inner.st_gid()
-            }
-            else if #[cfg(target_os = "unix")] {
+            if #[cfg(target_os = "unix")] {
                 self.inner.gid()
             } else {
                 0
@@ -269,10 +246,7 @@ impl Metadata for Meta {
 
     fn uid(&self) -> u32 {
         cfg_if! {
-            if #[cfg(target_os = "linux")] {
-                self.inner.st_uid()
-            }
-            else if #[cfg(target_os = "unix")] {
+            if #[cfg(target_os = "unix")] {
                 self.inner.uid()
             } else {
                 0
@@ -282,10 +256,7 @@ impl Metadata for Meta {
 
     fn links(&self) -> u64 {
         cfg_if! {
-            if #[cfg(target_os = "linux")] {
-                self.inner.st_nlink()
-            }
-            else if #[cfg(target_os = "unix")] {
+            if #[cfg(target_os = "unix")] {
                 self.inner.nlink()
             } else {
                 1

--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -11,7 +11,9 @@
 //!     let ftp_home = std::env::temp_dir();
 //!     let server = libunftp::Server::with_fs(ftp_home)
 //!         .greeting("Welcome to my FTP server")
-//!         .passive_ports(50000..65535);
+//!         .passive_ports(50000..65535)
+//!         .build()
+//!         .unwrap();
 //!
 //!     server.listen("127.0.0.1:2121").await;
 //! }

--- a/crates/unftp-sbe-fs/src/tests.rs
+++ b/crates/unftp-sbe-fs/src/tests.rs
@@ -7,6 +7,13 @@ use std::io::Write;
 use tokio::runtime::Runtime;
 
 #[test]
+fn fs_strip_prefixes() {
+    assert_eq!(strip_prefixes(Path::new("foo/bar")), Path::new("foo/bar"));
+    assert_eq!(strip_prefixes(Path::new("/foo/bar")), Path::new("foo/bar"));
+    assert_eq!(strip_prefixes(Path::new("/")), Path::new("."));
+}
+
+#[test]
 fn fs_stat() {
     let root = std::env::temp_dir();
 

--- a/crates/unftp-sbe-fs/tests/main.rs
+++ b/crates/unftp-sbe-fs/tests/main.rs
@@ -39,7 +39,10 @@ where
     let tempdir = tempfile::TempDir::new().unwrap();
     let root = tempdir.path().to_path_buf();
 
-    let server = s(root.clone()).build().unwrap().listen(addr.clone());
+    let server = s(root.clone()).build()
+        .await
+        .unwrap()
+        .listen(addr.clone());
 
     tokio::spawn(server);
     while async_ftp::FtpStream::connect(&addr).await.is_err() {

--- a/crates/unftp-sbe-fs/tests/main.rs
+++ b/crates/unftp-sbe-fs/tests/main.rs
@@ -39,10 +39,7 @@ where
     let tempdir = tempfile::TempDir::new().unwrap();
     let root = tempdir.path().to_path_buf();
 
-    let server = s(root.clone()).build()
-        .await
-        .unwrap()
-        .listen(addr.clone());
+    let server = s(root.clone()).build().await.unwrap().listen(addr.clone());
 
     tokio::spawn(server);
     while async_ftp::FtpStream::connect(&addr).await.is_err() {

--- a/crates/unftp-sbe-gcs/examples/gcs.rs
+++ b/crates/unftp-sbe-gcs/examples/gcs.rs
@@ -92,6 +92,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         }))
         .ftps(ftps_certs_file, ftps_key_file)
         .build()
+        .await
         .unwrap()
         .listen(BIND_ADDRESS)
         .await?;
@@ -100,6 +101,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             unftp_sbe_gcs::CloudStorage::with_api_base(&gcs_base_url, &bucket_name, PathBuf::new(), service_account_key.clone())
         }))
         .build()
+        .await
         .unwrap()
         .listen(BIND_ADDRESS)
         .await?;

--- a/crates/unftp-sbe-gcs/examples/gcs.rs
+++ b/crates/unftp-sbe-gcs/examples/gcs.rs
@@ -87,16 +87,20 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         let ftps_key_file = matches
             .value_of(FTPS_KEY_FILE)
             .ok_or("Internal error: use of an undefined command line parameter")?;
-        libunftp::Server::new(Box::new(move || {
+        libunftp::ServerBuilder::new(Box::new(move || {
             unftp_sbe_gcs::CloudStorage::with_api_base(&gcs_base_url, &bucket_name, PathBuf::new(), service_account_key.clone())
         }))
         .ftps(ftps_certs_file, ftps_key_file)
+        .build()
+        .unwrap()
         .listen(BIND_ADDRESS)
         .await?;
     } else {
-        libunftp::Server::new(Box::new(move || {
+        libunftp::ServerBuilder::new(Box::new(move || {
             unftp_sbe_gcs::CloudStorage::with_api_base(&gcs_base_url, &bucket_name, PathBuf::new(), service_account_key.clone())
         }))
+        .build()
+        .unwrap()
         .listen(BIND_ADDRESS)
         .await?;
     }

--- a/crates/unftp-sbe-gcs/src/ext.rs
+++ b/crates/unftp-sbe-gcs/src/ext.rs
@@ -1,7 +1,7 @@
 use crate::options::AuthMethod;
 use crate::CloudStorage;
 use libunftp::auth::DefaultUser;
-use libunftp::Server;
+use libunftp::{Server, ServerBuilder};
 use std::path::PathBuf;
 
 /// Extension trait purely for construction convenience.
@@ -15,16 +15,17 @@ pub trait ServerExt {
     /// use unftp_sbe_gcs::{ServerExt, options::AuthMethod};
     /// use std::path::PathBuf;
     ///
-    /// let server = Server::with_gcs("my-bucket", PathBuf::from("/unftp"), AuthMethod::WorkloadIdentity(None));
+    /// let server = Server::with_gcs("my-bucket", PathBuf::from("/unftp"), AuthMethod::WorkloadIdentity(None))
+    ///     .build();
     /// ```
-    fn with_gcs<Str, AuthHow>(bucket: Str, root: PathBuf, auth: AuthHow) -> Server<CloudStorage, DefaultUser>
+    fn with_gcs<Str, AuthHow>(bucket: Str, root: PathBuf, auth: AuthHow) -> ServerBuilder<CloudStorage, DefaultUser>
     where
         Str: Into<String>,
         AuthHow: Into<AuthMethod>,
     {
         let s = bucket.into();
         let a = auth.into();
-        libunftp::Server::new(Box::new(move || CloudStorage::with_bucket_root(s.clone(), root.clone(), a.clone())))
+        libunftp::ServerBuilder::new(Box::new(move || CloudStorage::with_bucket_root(s.clone(), root.clone(), a.clone())))
     }
 }
 

--- a/crates/unftp-sbe-gcs/src/lib.rs
+++ b/crates/unftp-sbe-gcs/src/lib.rs
@@ -28,7 +28,9 @@
 //! pub async fn main() {
 //!     let server = Server::with_gcs("my-bucket", PathBuf::from("/unftp"), AuthMethod::WorkloadIdentity(None))
 //!       .greeting("Welcome to my FTP server")
-//!       .passive_ports(50000..65535);
+//!       .passive_ports(50000..65535)
+//!       .build()
+//!       .unwrap();
 //!
 //!     server.listen("127.0.0.1:2121").await;
 //! }
@@ -48,7 +50,9 @@
 //!         Box::new(move || CloudStorage::with_bucket_root("my-bucket", PathBuf::from("/ftp-root"), AuthMethod::WorkloadIdentity(None)))
 //!       )
 //!       .greeting("Welcome to my FTP server")
-//!       .passive_ports(50000..65535);
+//!       .passive_ports(50000..65535)
+//!       .build()
+//!       .unwrap();
 //!
 //!     server.listen("127.0.0.1:2121").await;
 //! }

--- a/crates/unftp-sbe-gcs/src/lib.rs
+++ b/crates/unftp-sbe-gcs/src/lib.rs
@@ -30,6 +30,7 @@
 //!       .greeting("Welcome to my FTP server")
 //!       .passive_ports(50000..65535)
 //!       .build()
+//!       .await
 //!       .unwrap();
 //!
 //!     server.listen("127.0.0.1:2121").await;
@@ -52,6 +53,7 @@
 //!       .greeting("Welcome to my FTP server")
 //!       .passive_ports(50000..65535)
 //!       .build()
+//!       .await
 //!       .unwrap();
 //!
 //!     server.listen("127.0.0.1:2121").await;

--- a/crates/unftp-sbe-gcs/tests/main.rs
+++ b/crates/unftp-sbe-gcs/tests/main.rs
@@ -284,6 +284,7 @@ async fn run_test(test: impl Future<Output = ()>) {
         }))
         .logger(Some(Logger::root(drain, o!())))
         .build()
+        .await
         .unwrap()
         .listen(ADDR),
     );

--- a/crates/unftp-sbe-gcs/tests/main.rs
+++ b/crates/unftp-sbe-gcs/tests/main.rs
@@ -1,6 +1,6 @@
 use async_ftp::FtpStream;
 use lazy_static::*;
-use libunftp::Server;
+use libunftp::ServerBuilder;
 use unftp_sbe_gcs::CloudStorage;
 
 use more_asserts::assert_ge;
@@ -279,10 +279,12 @@ async fn run_test(test: impl Future<Output = ()>) {
     let drain = slog_async::Async::new(drain).build().fuse();
 
     tokio::spawn(
-        Server::new(Box::new(move || {
+        ServerBuilder::new(Box::new(move || {
             CloudStorage::with_api_base(GCS_BASE_URL, GCS_BUCKET, PathBuf::from("/"), AuthMethod::None)
         }))
         .logger(Some(Logger::root(drain, o!())))
+        .build()
+        .unwrap()
         .listen(ADDR),
     );
 

--- a/src/auth/user.rs
+++ b/src/auth/user.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::{self, Debug, Display, Formatter},
-    path::Path
+    path::Path,
 };
 
 /// UserDetail defines the requirements for implementations that hold _Security Subject_

--- a/src/auth/user.rs
+++ b/src/auth/user.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Debug, Display, Formatter};
+use std::{
+    fmt::{self, Debug, Display, Formatter},
+    path::Path
+};
 
 /// UserDetail defines the requirements for implementations that hold _Security Subject_
 /// information for use by the server.
@@ -15,6 +18,14 @@ pub trait UserDetail: Send + Sync + Display + Debug {
     /// Tells if this subject's account is enabled. This default implementation simply returns true.
     fn account_enabled(&self) -> bool {
         true
+    }
+
+    /// Returns the user's home directory, if any.  If the user has a home directory, then their
+    /// sessions will be restricted to this directory.
+    ///
+    /// The path should be absolute.
+    fn home(&self) -> Option<&Path> {
+        None
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //!         .greeting("Welcome to my FTP server")
 //!         .passive_ports(50000..65535)
 //!         .build()
+//!         .await
 //!         .unwrap();
 //!
 //!     server.listen("127.0.0.1:2121").await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,9 @@
 //!     let ftp_home = std::env::temp_dir();
 //!     let server = libunftp::Server::with_fs(ftp_home)
 //!         .greeting("Welcome to my FTP server")
-//!         .passive_ports(50000..65535);
+//!         .passive_ports(50000..65535)
+//!         .build()
+//!         .unwrap();
 //!
 //!     server.listen("127.0.0.1:2121").await;
 //! }
@@ -50,6 +52,6 @@ pub mod notification;
 pub(crate) mod server;
 pub mod storage;
 
-pub use crate::server::ftpserver::{error::ServerError, options, Server};
+pub use crate::server::ftpserver::{error::ServerError, options, Server, ServerBuilder};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/src/notification/event.rs
+++ b/src/notification/event.rs
@@ -70,7 +70,7 @@ pub struct EventMeta {
 }
 
 /// An listener for [`DataEvent`](crate::notification::DataEvent)s. Implementations can
-/// be passed to [`Server::notify_data`](crate::Server::notify_data)
+/// be passed to [`ServerBuilder::notify_data`](crate::ServerBuilder::notify_data)
 /// in order to receive notifications.
 #[async_trait]
 pub trait DataListener: Sync + Send + Debug {
@@ -79,8 +79,8 @@ pub trait DataListener: Sync + Send + Debug {
     async fn receive_data_event(&self, e: DataEvent, m: EventMeta);
 }
 
-/// An listener for [`PresenceEvent`](crate::notification::PresenceEvent)s. Implementations can
-/// be passed to [`Server::notify_presence`](crate::Server::notify_presence)
+/// A listener for [`PresenceEvent`](crate::notification::PresenceEvent)s. Implementations can
+/// be passed to [`ServerBuilder::notify_presence`](crate::ServerBuilder::notify_presence)
 /// in order to receive notifications.
 #[async_trait]
 pub trait PresenceListener: Sync + Send + Debug {

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -3,11 +3,11 @@
 //! Allows users to listen to events emitted by libunftp.
 //!
 //! To listen for changes in data implement the [`DataListener`]
-//! trait and use the [`Server::notify_data`](crate::Server::notify_data) method
+//! trait and use the [`ServerBuilder::notify_data`](crate::ServerBuilder::notify_data) method
 //! to make libunftp notify it.
 //!
 //! To listen to logins and logouts implement the [`PresenceListener`]
-//! trait and use the [`Server::notify_presence`](crate::Server::notify_data) method
+//! trait and use the [`ServerBuilder::notify_presence`](crate::ServerBuilder::notify_data) method
 //! to make libunftp use it.
 //!
 

--- a/src/server/controlchan/commands/pass.rs
+++ b/src/server/controlchan/commands/pass.rs
@@ -104,34 +104,26 @@ where
                                 ControlChanMsg::AuthFailed
                             } else if user.account_enabled() {
                                 let mut session = session2clone.lock().await;
-                                slog::info!(logger, "PASS: User {} logged in", user);
-                                if let Some(home) = user.home() {
-                                    // Using Arc::get_mut means that this won't work if the Session
-                                    // is currently servicing multiple commands concurrently.  But
-                                    // it shouldn't ever be servicing PASS at the same time as
-                                    // another command.
-                                    match Arc::get_mut(&mut session.storage).map(|s| s.enter(home)) {
-                                        Some(Err(e)) => {
-                                            slog::error!(logger, "{}", e);
-                                            ControlChanMsg::AuthFailed
-                                        }
-                                        None => {
-                                            slog::error!(logger, "Failed to lock Session::storage during PASS.");
-                                            ControlChanMsg::AuthFailed
-                                        }
-                                        Some(Ok(())) => {
-                                            session.user = Arc::new(Some(user));
-                                            ControlChanMsg::AuthSuccess {
-                                                username,
-                                                trace_id: session.trace_id,
-                                            }
-                                        }
+                                // Using Arc::get_mut means that this won't work if the Session is
+                                // currently servicing multiple commands concurrently.  But it
+                                // shouldn't ever be servicing PASS at the same time as another
+                                // command.
+                                match Arc::get_mut(&mut session.storage).map(|s| s.enter(&user)) {
+                                    Some(Err(e)) => {
+                                        slog::error!(logger, "{}", e);
+                                        ControlChanMsg::AuthFailed
                                     }
-                                } else {
-                                    session.user = Arc::new(Some(user));
-                                    ControlChanMsg::AuthSuccess {
-                                        username,
-                                        trace_id: session.trace_id,
+                                    None => {
+                                        slog::error!(logger, "Failed to lock Session::storage during PASS.");
+                                        ControlChanMsg::AuthFailed
+                                    }
+                                    Some(Ok(())) => {
+                                        slog::info!(logger, "PASS: User {} logged in", user);
+                                        session.user = Arc::new(Some(user));
+                                        ControlChanMsg::AuthSuccess {
+                                            username,
+                                            trace_id: session.trace_id,
+                                        }
                                     }
                                 }
                             } else {

--- a/src/server/controlchan/commands/pass.rs
+++ b/src/server/controlchan/commands/pass.rs
@@ -114,7 +114,7 @@ where
                                         Some(Err(e)) => {
                                             slog::error!(logger, "{}", e);
                                             ControlChanMsg::AuthFailed
-                                        },
+                                        }
                                         None => {
                                             slog::error!(logger, "Failed to lock Session::storage during PASS.");
                                             ControlChanMsg::AuthFailed

--- a/src/server/controlchan/commands/pass.rs
+++ b/src/server/controlchan/commands/pass.rs
@@ -105,10 +105,34 @@ where
                             } else if user.account_enabled() {
                                 let mut session = session2clone.lock().await;
                                 slog::info!(logger, "PASS: User {} logged in", user);
-                                session.user = Arc::new(Some(user));
-                                ControlChanMsg::AuthSuccess {
-                                    username,
-                                    trace_id: session.trace_id,
+                                if let Some(home) = user.home() {
+                                    // Using Arc::get_mut means that this won't work if the Session
+                                    // is currently servicing multiple commands concurrently.  But
+                                    // it shouldn't ever be servicing PASS at the same time as
+                                    // another command.
+                                    match Arc::get_mut(&mut session.storage).map(|s| s.enter(home)) {
+                                        Some(Err(e)) => {
+                                            slog::error!(logger, "{}", e);
+                                            ControlChanMsg::AuthFailed
+                                        },
+                                        None => {
+                                            slog::error!(logger, "Failed to lock Session::storage during PASS.");
+                                            ControlChanMsg::AuthFailed
+                                        }
+                                        Some(Ok(())) => {
+                                            session.user = Arc::new(Some(user));
+                                            ControlChanMsg::AuthSuccess {
+                                                username,
+                                                trace_id: session.trace_id,
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    session.user = Arc::new(Some(user));
+                                    ControlChanMsg::AuthSuccess {
+                                        username,
+                                        trace_id: session.trace_id,
+                                    }
                                 }
                             } else {
                                 slog::warn!(logger, "PASS: User {} authenticated but account is disabled", user);

--- a/src/server/controlchan/commands/pasv.rs
+++ b/src/server/controlchan/commands/pasv.rs
@@ -24,15 +24,17 @@ use crate::{
 };
 use async_trait::async_trait;
 use std::{io, net::SocketAddr, ops::Range};
-use std::{net::{IpAddr, Ipv4Addr}, time::Duration};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    time::Duration,
+};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 const BIND_RETRIES: u8 = 10;
 
 #[derive(Debug)]
-pub struct Pasv {
-}
+pub struct Pasv {}
 
 impl Pasv {
     pub fn new() -> Self {
@@ -108,9 +110,7 @@ impl Pasv {
             }
         };
 
-        let olistener = {
-            session.lock().await.listener.take()
-        };
+        let olistener = { session.lock().await.listener.take() };
         let listener = if let Some(listener) = olistener {
             listener
         } else {

--- a/src/server/controlchan/commands/user.rs
+++ b/src/server/controlchan/commands/user.rs
@@ -57,6 +57,7 @@ where
                         session.username = Some(user.to_string());
                         session.state = SessionState::WaitCmd;
                         session.user = Arc::new(Some(user_detail));
+                        // TODO: enter capsicum here.
                         Ok(Reply::new(ReplyCode::UserLoggedInViaCert, "User logged in"))
                     }
                     Err(_e) => Ok(Reply::new(ReplyCode::NotLoggedIn, "Invalid credentials")),

--- a/src/server/controlchan/commands/user.rs
+++ b/src/server/controlchan/commands/user.rs
@@ -54,11 +54,33 @@ where
                 match auth_result {
                     Ok(user_detail) => {
                         let user = username_str;
-                        session.username = Some(user.to_string());
-                        session.state = SessionState::WaitCmd;
-                        session.user = Arc::new(Some(user_detail));
-                        // TODO: enter capsicum here.
-                        Ok(Reply::new(ReplyCode::UserLoggedInViaCert, "User logged in"))
+                        if let Some(home) = user_detail.home() {
+                            // Using Arc::get_mut means that this won't work if the Session is
+                            // currently servicing multiple commands concurrently.  But it
+                            // shouldn't ever be servicing USER at the same time as another
+                            // command.
+                            match Arc::get_mut(&mut session.storage).map(|s| s.enter(home)) {
+                                Some(Err(e)) => {
+                                    slog::error!(args.logger, "{}", e);
+                                    Ok(Reply::new(ReplyCode::NotLoggedIn, "Invalid credentials"))
+                                },
+                                None => {
+                                    slog::error!(args.logger, "Failed to lock Session::storage during USER.");
+                                    Ok(Reply::new(ReplyCode::NotLoggedIn, "Temporarily unavailable"))
+                                }
+                                Some(Ok(())) => {
+                                    session.username = Some(user.to_string());
+                                    session.state = SessionState::WaitCmd;
+                                    session.user = Arc::new(Some(user_detail));
+                                    Ok(Reply::new(ReplyCode::UserLoggedInViaCert, "User logged in"))
+                                }
+                            }
+                        } else {
+                            session.username = Some(user.to_string());
+                            session.state = SessionState::WaitCmd;
+                            session.user = Arc::new(Some(user_detail));
+                            Ok(Reply::new(ReplyCode::UserLoggedInViaCert, "User logged in"))
+                        }
                     }
                     Err(_e) => Ok(Reply::new(ReplyCode::NotLoggedIn, "Invalid credentials")),
                 }

--- a/src/server/controlchan/commands/user.rs
+++ b/src/server/controlchan/commands/user.rs
@@ -63,7 +63,7 @@ where
                                 Some(Err(e)) => {
                                     slog::error!(args.logger, "{}", e);
                                     Ok(Reply::new(ReplyCode::NotLoggedIn, "Invalid credentials"))
-                                },
+                                }
                                 None => {
                                     slog::error!(args.logger, "Failed to lock Session::storage during USER.");
                                     Ok(Reply::new(ReplyCode::NotLoggedIn, "Temporarily unavailable"))

--- a/src/server/controlchan/commands/user.rs
+++ b/src/server/controlchan/commands/user.rs
@@ -54,32 +54,24 @@ where
                 match auth_result {
                     Ok(user_detail) => {
                         let user = username_str;
-                        if let Some(home) = user_detail.home() {
-                            // Using Arc::get_mut means that this won't work if the Session is
-                            // currently servicing multiple commands concurrently.  But it
-                            // shouldn't ever be servicing USER at the same time as another
-                            // command.
-                            match Arc::get_mut(&mut session.storage).map(|s| s.enter(home)) {
-                                Some(Err(e)) => {
-                                    slog::error!(args.logger, "{}", e);
-                                    Ok(Reply::new(ReplyCode::NotLoggedIn, "Invalid credentials"))
-                                }
-                                None => {
-                                    slog::error!(args.logger, "Failed to lock Session::storage during USER.");
-                                    Ok(Reply::new(ReplyCode::NotLoggedIn, "Temporarily unavailable"))
-                                }
-                                Some(Ok(())) => {
-                                    session.username = Some(user.to_string());
-                                    session.state = SessionState::WaitCmd;
-                                    session.user = Arc::new(Some(user_detail));
-                                    Ok(Reply::new(ReplyCode::UserLoggedInViaCert, "User logged in"))
-                                }
+                        // Using Arc::get_mut means that this won't work if the Session is
+                        // currently servicing multiple commands concurrently.  But it shouldn't
+                        // ever be servicing USER at the same time as another command.
+                        match Arc::get_mut(&mut session.storage).map(|s| s.enter(&user_detail)) {
+                            Some(Err(e)) => {
+                                slog::error!(args.logger, "{}", e);
+                                Ok(Reply::new(ReplyCode::NotLoggedIn, "Invalid credentials"))
                             }
-                        } else {
-                            session.username = Some(user.to_string());
-                            session.state = SessionState::WaitCmd;
-                            session.user = Arc::new(Some(user_detail));
-                            Ok(Reply::new(ReplyCode::UserLoggedInViaCert, "User logged in"))
+                            None => {
+                                slog::error!(args.logger, "Failed to lock Session::storage during USER.");
+                                Ok(Reply::new(ReplyCode::NotLoggedIn, "Temporarily unavailable"))
+                            }
+                            Some(Ok(())) => {
+                                session.username = Some(user.to_string());
+                                session.state = SessionState::WaitCmd;
+                                session.user = Arc::new(Some(user_detail));
+                                Ok(Reply::new(ReplyCode::UserLoggedInViaCert, "User logged in"))
+                            }
                         }
                     }
                     Err(_e) => Ok(Reply::new(ReplyCode::NotLoggedIn, "Invalid credentials")),

--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -69,7 +69,7 @@ where
     pub data_listener: Arc<dyn DataListener>,
     pub presence_listener: Arc<dyn PresenceListener>,
     pub active_passive_mode: ActivePassiveMode,
-    pub pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpListener>>>,
+    pub pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpSocket>>>,
 }
 
 /// Does TCP processing when an FTP client connects

--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -69,7 +69,7 @@ where
     pub data_listener: Arc<dyn DataListener>,
     pub presence_listener: Arc<dyn PresenceListener>,
     pub active_passive_mode: ActivePassiveMode,
-    pub pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpSocket>>>,
+    pub binder: Arc<std::sync::Mutex<Option<Box<dyn crate::options::Binder>>>>,
 }
 
 /// Does TCP processing when an FTP client connects
@@ -102,7 +102,7 @@ where
         data_listener,
         presence_listener,
         active_passive_mode,
-        pasv_listener,
+        binder,
         ..
     } = config;
 
@@ -116,8 +116,8 @@ where
         .control_msg_tx(control_msg_tx.clone())
         .proxy_connection(proxy_connection)
         .failed_logins(failed_logins);
-    if let Some(s) = pasv_listener.lock().unwrap().take() {
-        session = session.pasv_listener(s);
+    if let Some(b) = binder.lock().unwrap().take() {
+        session = session.binder(b);
     }
 
     let mut logger = logger.new(

--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -69,7 +69,7 @@ where
     pub data_listener: Arc<dyn DataListener>,
     pub presence_listener: Arc<dyn PresenceListener>,
     pub active_passive_mode: ActivePassiveMode,
-    pub pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpListener>>>
+    pub pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpListener>>>,
 }
 
 /// Does TCP processing when an FTP client connects

--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -449,7 +449,11 @@ where
 /// session_arc: the user session that is also shared with the control channel.
 /// socket: the data socket we'll be working with.
 #[tracing_attributes::instrument]
-pub async fn spawn_processing<Storage, User>(logger: slog::Logger, session_arc: SharedSession<Storage, User>, mut socket: TcpStream)
+pub async fn spawn_processing<Storage, User>(
+    logger: slog::Logger,
+    session_arc: SharedSession<Storage, User>,
+    mut socket: TcpStream
+)
 where
     Storage: StorageBackend<User> + 'static,
     Storage::Metadata: Metadata,

--- a/src/server/datachan.rs
+++ b/src/server/datachan.rs
@@ -449,11 +449,7 @@ where
 /// session_arc: the user session that is also shared with the control channel.
 /// socket: the data socket we'll be working with.
 #[tracing_attributes::instrument]
-pub async fn spawn_processing<Storage, User>(
-    logger: slog::Logger,
-    session_arc: SharedSession<Storage, User>,
-    mut socket: TcpStream
-)
+pub async fn spawn_processing<Storage, User>(logger: slog::Logger, session_arc: SharedSession<Storage, User>, mut socket: TcpStream)
 where
     Storage: StorageBackend<User> + 'static,
     Storage::Metadata: Metadata,

--- a/src/server/ftpserver.rs
+++ b/src/server/ftpserver.rs
@@ -751,7 +751,7 @@ where
         }
     }
 
-    /// Service a newly established connection.
+    /// Service a newly established connection as a control connection.
     ///
     /// Use this method instead of [`listen`](Server::listen) if you want to listen for and accept
     /// new connections yourself, instead of using libunftp to do it.

--- a/src/server/ftpserver.rs
+++ b/src/server/ftpserver.rs
@@ -74,7 +74,7 @@ where
     active_passive_mode: ActivePassiveMode,
     connection_helper: Option<OsString>,
     connection_helper_args: Vec<OsString>,
-    pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpListener>>>,
+    pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpSocket>>>,
 }
 
 /// Used to create [`Server`]s.  
@@ -214,7 +214,7 @@ where
             FtpsConfig::On { tls_config } => FtpsConfig::On { tls_config },
         };
         let pasv_listener = Arc::new(std::sync::Mutex::new(match self.pasv_listener_addr {
-            Some(addr) => Some(crate::server::controlchan::commands::Pasv::try_port_range(addr, self.passive_ports.clone()).await?),
+            Some(addr) => Some(crate::server::controlchan::commands::Pasv::try_port_range(addr, self.passive_ports.clone())?),
             None => None,
         }));
         Ok(Server {

--- a/src/server/ftpserver.rs
+++ b/src/server/ftpserver.rs
@@ -106,7 +106,7 @@ where
     active_passive_mode: ActivePassiveMode,
     connection_helper: Option<OsString>,
     connection_helper_args: Vec<OsString>,
-    pasv_listener_addr: Option<std::net::IpAddr>
+    pasv_listener_addr: Option<std::net::IpAddr>,
 }
 
 impl<Storage, User> ServerBuilder<Storage, User>
@@ -214,11 +214,8 @@ where
             FtpsConfig::On { tls_config } => FtpsConfig::On { tls_config },
         };
         let pasv_listener = Arc::new(std::sync::Mutex::new(match self.pasv_listener_addr {
-            Some(addr) => {
-                Some(crate::server::controlchan::commands::Pasv::try_port_range(addr, self.passive_ports.clone())
-                    .await?)
-            },
-            None => None
+            Some(addr) => Some(crate::server::controlchan::commands::Pasv::try_port_range(addr, self.passive_ports.clone()).await?),
+            None => None,
         }));
         Ok(Server {
             storage: self.storage,

--- a/src/server/ftpserver.rs
+++ b/src/server/ftpserver.rs
@@ -482,7 +482,7 @@ where
     ///
     /// Preallocate a socket suitable for servicing the PASV command as received from the given IP
     /// address.  This method is completely optional, but it is necessary in order to use the
-    /// [`service`] method when the server is running in capability mode.
+    /// [`Server::service`] method when the server is running in capability mode.
     // In the future, this could be extended to accept multiple invocations, allocating a
     // collection of sockets.
     pub async fn pasv_listener(self, addr: std::net::IpAddr) -> Self {

--- a/src/server/ftpserver/chosen.rs
+++ b/src/server/ftpserver/chosen.rs
@@ -34,6 +34,7 @@ where
     pub data_listener: Arc<dyn DataListener>,
     pub presence_listener: Arc<dyn PresenceListener>,
     pub active_passive_mode: ActivePassiveMode,
+    pub pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpListener>>>
 }
 
 impl<Storage, User> From<&OptionsHolder<Storage, User>> for controlchan::LoopConfig<Storage, User>
@@ -43,6 +44,8 @@ where
     Storage::Metadata: Metadata,
 {
     fn from(server: &OptionsHolder<Storage, User>) -> Self {
+        // So this is when you create a new storage backend?
+        // XXX Shouldn't instantiate storage until _after_ successful auth.
         controlchan::LoopConfig {
             authenticator: server.authenticator.clone(),
             storage: (server.storage)(),
@@ -59,6 +62,7 @@ where
             data_listener: server.data_listener.clone(),
             presence_listener: server.presence_listener.clone(),
             active_passive_mode: server.active_passive_mode,
+            pasv_listener: server.pasv_listener.clone()
         }
     }
 }

--- a/src/server/ftpserver/chosen.rs
+++ b/src/server/ftpserver/chosen.rs
@@ -34,7 +34,7 @@ where
     pub data_listener: Arc<dyn DataListener>,
     pub presence_listener: Arc<dyn PresenceListener>,
     pub active_passive_mode: ActivePassiveMode,
-    pub pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpSocket>>>,
+    pub binder: Arc<std::sync::Mutex<Option<Box<dyn crate::options::Binder>>>>,
 }
 
 impl<Storage, User> From<&OptionsHolder<Storage, User>> for controlchan::LoopConfig<Storage, User>
@@ -62,7 +62,7 @@ where
             data_listener: server.data_listener.clone(),
             presence_listener: server.presence_listener.clone(),
             active_passive_mode: server.active_passive_mode,
-            pasv_listener: server.pasv_listener.clone(),
+            binder: server.binder.clone(),
         }
     }
 }

--- a/src/server/ftpserver/chosen.rs
+++ b/src/server/ftpserver/chosen.rs
@@ -34,7 +34,7 @@ where
     pub data_listener: Arc<dyn DataListener>,
     pub presence_listener: Arc<dyn PresenceListener>,
     pub active_passive_mode: ActivePassiveMode,
-    pub pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpListener>>>
+    pub pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpListener>>>,
 }
 
 impl<Storage, User> From<&OptionsHolder<Storage, User>> for controlchan::LoopConfig<Storage, User>
@@ -62,7 +62,7 @@ where
             data_listener: server.data_listener.clone(),
             presence_listener: server.presence_listener.clone(),
             active_passive_mode: server.active_passive_mode,
-            pasv_listener: server.pasv_listener.clone()
+            pasv_listener: server.pasv_listener.clone(),
         }
     }
 }

--- a/src/server/ftpserver/chosen.rs
+++ b/src/server/ftpserver/chosen.rs
@@ -34,7 +34,7 @@ where
     pub data_listener: Arc<dyn DataListener>,
     pub presence_listener: Arc<dyn PresenceListener>,
     pub active_passive_mode: ActivePassiveMode,
-    pub pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpListener>>>,
+    pub pasv_listener: Arc<std::sync::Mutex<Option<tokio::net::TcpSocket>>>,
 }
 
 impl<Storage, User> From<&OptionsHolder<Storage, User>> for controlchan::LoopConfig<Storage, User>

--- a/src/server/ftpserver/listen.rs
+++ b/src/server/ftpserver/listen.rs
@@ -5,8 +5,8 @@ use crate::server::failed_logins::FailedLoginsCache;
 use crate::server::shutdown;
 use crate::{auth::UserDetail, server::controlchan, storage::StorageBackend};
 use std::ffi::OsString;
-use std::os::fd::AsRawFd;
 use std::net::SocketAddr;
+use std::os::fd::AsRawFd;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 
@@ -23,7 +23,7 @@ where
     pub shutdown_topic: Arc<shutdown::Notifier>,
     pub failed_logins: Option<Arc<FailedLoginsCache>>,
     pub connection_helper: Option<OsString>,
-    pub connection_helper_args: Vec<OsString>
+    pub connection_helper_args: Vec<OsString>,
 }
 
 impl<Storage, User> Listener<Storage, User>
@@ -40,7 +40,7 @@ where
             shutdown_topic,
             failed_logins,
             connection_helper,
-            connection_helper_args
+            connection_helper_args,
         } = self;
         let listener = TcpListener::bind(bind_address).await?;
         loop {
@@ -65,19 +65,14 @@ where
                                 });
                             }
                             Err(err) => {
-                                slog::error!(logger,
-                                    "Could not spawn helper process for connection from {:?}: {:?}",
-                                    socket_addr, err);
+                                slog::error!(logger, "Could not spawn helper process for connection from {:?}: {:?}", socket_addr, err);
                             }
                         }
                     } else {
                         let result =
-                            controlchan::spawn_loop::<Storage, User>((&options).into(), tcp_stream,
-                                None, None, shutdown_listener, failed_logins.clone()).await;
+                            controlchan::spawn_loop::<Storage, User>((&options).into(), tcp_stream, None, None, shutdown_listener, failed_logins.clone()).await;
                         if let Err(err) = result {
-                            slog::error!(logger,
-                                "Could not spawn control channel loop for connection from {:?}: {:?}",
-                                socket_addr, err);
+                            slog::error!(logger, "Could not spawn control channel loop for connection from {:?}: {:?}", socket_addr, err);
                         }
                     }
                 }

--- a/src/server/ftpserver/options.rs
+++ b/src/server/ftpserver/options.rs
@@ -1,4 +1,4 @@
-//! Contains code pertaining to the setup options that can be given to the [`Server`](crate::Server)
+//! Contains code pertaining to the setup options that can be given to the [`ServerBuilder`](crate::ServerBuilder)
 
 use bitflags::bitflags;
 use std::time::Duration;
@@ -18,7 +18,7 @@ pub(crate) const DEFAULT_PASSIVE_PORTS: Range<u16> = 49152..65535;
 pub(crate) const DEFAULT_FTPS_REQUIRE: FtpsRequired = FtpsRequired::None;
 pub(crate) const DEFAULT_FTPS_TRUST_STORE: &str = "./trusted.pem";
 
-/// The option to [Server.passive_host](crate::Server::passive_host). It allows the user to specify how the IP address
+/// The option to [ServerBuilder::passive_host](crate::ServerBuilder::passive_host). It allows the user to specify how the IP address
 /// communicated in the _PASV_ response is determined.
 #[derive(Debug, PartialEq, Clone, Default)]
 pub enum PassiveHost {
@@ -57,7 +57,7 @@ impl From<&str> for PassiveHost {
     }
 }
 
-/// The option to [Server.ftps_required](crate::Server::ftps_required). It allows the user to specify whether clients are required
+/// The option to [ServerBuilder::ftps_required](crate::ServerBuilder::ftps_required). It allows the user to specify whether clients are required
 /// to upgrade a to secure TLS connection i.e. use FTPS.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum FtpsRequired {
@@ -119,7 +119,7 @@ impl Default for TlsFlags {
     }
 }
 
-/// The option to [Server.ftps_client_auth](crate::Server::ftps_client_auth). Tells if and how mutual TLS (client certificate
+/// The option to [ServerBuilder::ftps_client_auth](crate::ServerBuilder::ftps_client_auth). Tells if and how mutual TLS (client certificate
 /// authentication) should be handled.
 #[derive(Debug, PartialEq, Clone, Copy, Default)]
 pub enum FtpsClientAuth {
@@ -129,11 +129,11 @@ pub enum FtpsClientAuth {
     Off,
     /// Mutual TLS is on and whilst the server will request a certificate it will still proceed
     /// without one. If a certificate is sent by the client it will be validated against the
-    /// configured trust anchors (see [Server::ftps_trust_store](crate::Server::ftps_trust_store)).
+    /// configured trust anchors (see [ServerBuilder::ftps_trust_store](crate::ServerBuilder::ftps_trust_store)).
     Request,
     /// Mutual TLS is on, the server will request a certificate and it won't proceed without a
     /// client certificate that validates against the configured trust anchors (see
-    /// [Server::ftps_trust_store](crate::Server::ftps_trust_store)).
+    /// [ServerBuilder::ftps_trust_store](crate::ServerBuilder::ftps_trust_store)).
     Require,
 }
 
@@ -148,7 +148,7 @@ impl From<bool> for FtpsClientAuth {
     }
 }
 
-/// The options for [Server.sitemd5](crate::Server::sitemd5).
+/// The options for [ServerBuilder::sitemd5](crate::ServerBuilder::sitemd5).
 /// Allow MD5 either to be used by all, logged in users only or no one.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum SiteMd5 {
@@ -162,7 +162,8 @@ pub enum SiteMd5 {
 }
 
 /// Tells how graceful shutdown should happen. An instance of this struct should be returned from
-/// the future passed to [Server.shutdown_indicator](crate::Server::shutdown_indicator).
+/// the future passed to
+/// [ServerBuilder::shutdown_indicator](crate::ServerBuilder::shutdown_indicator).
 pub struct Shutdown {
     pub(crate) grace_period: Duration,
     //pub(crate) handle_new_connections: bool,
@@ -242,8 +243,9 @@ impl Default for FailedLoginsPolicy {
     }
 }
 
-/// The options for [Server.active_passive_mode](crate::Server::active_passive_mode).
-/// This allows to switch active / passive mode on or off.
+/// The options for
+/// [ServerBuilder::active_passive_mode](crate::ServerBuilder::active_passive_mode).  This allows
+/// to switch active / passive mode on or off.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum ActivePassiveMode {
     /// Only passive mode is enabled

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -16,8 +16,8 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
-use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::net::TcpListener;
+use tokio::sync::mpsc::{Receiver, Sender};
 
 // TraceId is an identifier used to correlate logs statements together.
 #[derive(PartialEq, Eq, Copy, Clone)]
@@ -149,7 +149,7 @@ where
             data_busy: false,
             cert_chain: None,
             failed_logins: None,
-            listener: None
+            listener: None,
         }
     }
 

--- a/src/storage/storage_backend.rs
+++ b/src/storage/storage_backend.rs
@@ -165,12 +165,12 @@ pub trait StorageBackend<User: UserDetail>: Send + Sync + Debug {
     /// The concrete type of the _metadata_ used by this storage backend.
     type Metadata: Metadata + Sync + Send;
 
-    /// Restrict the backend's capabilities so that it may only access files underneath `path`.
-    /// Once restricted, it may never be unrestricted.
+    /// Restrict the backend's capabilities commensurate with the provided
+    /// [`UserDetail`](crate::auth::UserDetail).
     ///
-    /// The path should be absolute.
-    fn enter<P: AsRef<Path>>(&mut self, _path: P) -> io::Result<()> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not supported by this StorageBackend"))
+    /// Once restricted, it may never be unrestricted.
+    fn enter<U: UserDetail>(&mut self, _user_detail: &U) -> io::Result<()> {
+        Ok(())
     }
 
     /// Implement to set the name of the storage back-end. By default it returns the type signature.

--- a/src/storage/storage_backend.rs
+++ b/src/storage/storage_backend.rs
@@ -12,6 +12,7 @@ use libc;
 use md5::{Digest, Md5};
 use std::{
     fmt::{self, Debug, Formatter, Write},
+    io,
     path::Path,
     result,
     time::SystemTime,
@@ -163,6 +164,14 @@ where
 pub trait StorageBackend<User: UserDetail>: Send + Sync + Debug {
     /// The concrete type of the _metadata_ used by this storage backend.
     type Metadata: Metadata + Sync + Send;
+
+    /// Restrict the backend's capabilities so that it may only access files underneath `path`.
+    /// Once restricted, it may never be unrestricted.
+    ///
+    /// The path should be absolute.
+    fn enter<P: AsRef<Path>>(&mut self, _path: P) -> io::Result<()> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported by this StorageBackend"))
+    }
 
     /// Implement to set the name of the storage back-end. By default it returns the type signature.
     fn name(&self) -> &str {

--- a/src/storage/storage_backend.rs
+++ b/src/storage/storage_backend.rs
@@ -169,7 +169,7 @@ pub trait StorageBackend<User: UserDetail>: Send + Sync + Debug {
     /// [`UserDetail`](crate::auth::UserDetail).
     ///
     /// Once restricted, it may never be unrestricted.
-    fn enter<U: UserDetail>(&mut self, _user_detail: &U) -> io::Result<()> {
+    fn enter(&mut self, _user_detail: &User) -> io::Result<()> {
         Ok(())
     }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -15,7 +15,9 @@ pub async fn run_with_auth() {
     let server = libunftp::Server::with_fs(std::env::temp_dir())
         .authenticator(Arc::new(TestAuthenticator {}))
         .greeting("Welcome test")
-        .failed_logins_policy(FailedLoginsPolicy::new(3, std::time::Duration::new(5, 0), FailedLoginsBlock::User));
+        .failed_logins_policy(FailedLoginsPolicy::new(3, std::time::Duration::new(5, 0), FailedLoginsBlock::User))
+        .build()
+        .unwrap();
     server.listen(addr).await.unwrap();
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -17,6 +17,7 @@ pub async fn run_with_auth() {
         .greeting("Welcome test")
         .failed_logins_policy(FailedLoginsPolicy::new(3, std::time::Duration::new(5, 0), FailedLoginsBlock::User))
         .build()
+        .await
         .unwrap();
     server.listen(addr).await.unwrap();
 }


### PR DESCRIPTION
Capsicum is a security technology that restricts processes from accessing any global namespaces.  After entering capsicum mode, a process may no longer use a syscall like open(); instead it's restricted to openat().

This PR:
* Modifies unftp-sbe-fs to work in capability mode, using cap-std
* Modifies libunftp to provide hooks for Capsicum-using consumers
* Extends libunftp-auth-jsonfile to allow per-user home directories
* Adds an example to unftp-sbe-fs demonstrating Capsicum mode.

Fixes #475 