### PR TITLE
fix RUSTSEC-2023-0052

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,13 +42,13 @@ md-5 = "0.10.5"
 moka = { version = "0.9.7", default-features = false, features = ["sync"] }
 prometheus = { version = "0.13.3", default-features = false }
 proxy-protocol = "0.5.0"
-rustls = "0.20.8"
+rustls = "0.21.6"
 rustls-pemfile = "1.0.2"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_info"] }
 slog-stdlog = "4.1.1"
 thiserror = "1.0.40"
 tokio = { version = "1.28.2", features = ["macros", "rt", "net", "sync", "io-util", "time"] }
-tokio-rustls = "0.23.4"
+tokio-rustls = "0.24.1"
 tokio-util = { version = "0.7.8", features = ["codec"] }
 tracing = { version = "0.1.37", default-features = false }
 tracing-attributes = "0.1.24"

--- a/crates/unftp-auth-rest/Cargo.toml
+++ b/crates/unftp-auth-rest/Cargo.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 [dependencies]
 async-trait = "0.1.68"
 hyper = { version = "0.14.26", features = ["client", "runtime", "stream", "http1"] }
-hyper-rustls = "0.23.2"
+hyper-rustls = "0.24.1"
 libunftp = { version="0.18.9", path="../../"}
 percent-encoding = "2.2.0"
 regex = "1.8.3"

--- a/crates/unftp-sbe-gcs/Cargo.toml
+++ b/crates/unftp-sbe-gcs/Cargo.toml
@@ -24,7 +24,7 @@ bytes = "1.4.0"
 chrono = { version = "0.4.26", default-features = false, features = ["std", "serde"] }
 futures = { version = "0.3.28", default-features = false, features = ["std"] }
 hyper = { version = "0.14.26", features = ["client", "runtime", "stream", "http1"] }
-hyper-rustls = "0.23.2"
+hyper-rustls = "0.24.1"
 libunftp = { version="0.18.9", path="../../"}
 mime = "0.3.17"
 percent-encoding = "2.2.0"
@@ -36,7 +36,7 @@ tokio-stream = "0.1.14"
 tokio-util = { version = "0.7.8", features = ["codec", "compat"] }
 tracing = { version = "0.1.37", default-features = false }
 tracing-attributes = "0.1.24"
-yup-oauth2 = "7.0.1"
+yup-oauth2 = "8.3.0"
 
 [dev-dependencies]
 async_ftp = "6.0.0"


### PR DESCRIPTION
by updating some dependencies that transitively pulled in the vulnerable version of webpki.