### PR TITLE
Fix issue introduced by PR #482

### DIFF
--- a/crates/unftp-sbe-gcs/src/gcs_client.rs
+++ b/crates/unftp-sbe-gcs/src/gcs_client.rs
@@ -451,7 +451,7 @@ impl Token {
 impl From<yup_oauth2::AccessToken> for Token {
     fn from(source: yup_oauth2::AccessToken) -> Self {
         Self {
-            value: source.as_str().to_string(),
+            value: source.token().unwrap_or("").to_string(),
             expires_at: source.expiration_time(),
         }
     }


### PR DESCRIPTION
Pull request #482 upgraded the major version of yup-oauth2. This broke the GCS client that was using a `as_str` method that no longer exists on the AccessToken struct.