### PR TITLE
Move lint defs to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,13 @@ members = [
     "crates/unftp-sbe-gcs"
 ]
 
+[workspace.lints.rust]
+unsafe_code = "deny"
+missing_docs = "deny"
+
+[workspace.lints.clippy]
+all = "deny"
+
 [dependencies]
 async-trait = "0.1.77"
 bitflags = "2.4.2"
@@ -63,7 +70,9 @@ pretty_assertions = "1.4.0"
 tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }
 unftp-sbe-fs = { path = "../libunftp/crates/unftp-sbe-fs"}
 
-
 [patch.crates-io]
 capsicum = { git = "https://github.com/asomers/capsicum-rs", rev = "24330ee"}
 casper-sys = { git = "https://github.com/asomers/capsicum-rs", rev = "24330ee"}
+
+[lints]
+workspace=true

--- a/crates/unftp-auth-jsonfile/Cargo.toml
+++ b/crates/unftp-auth-jsonfile/Cargo.toml
@@ -37,3 +37,6 @@ flate2 = "1.0.28"
 pretty_env_logger = "0.5.0"
 tokio = { version = "1.36.0", features = ["macros"] }
 unftp-sbe-fs = { version="0.2.2", path="../unftp-sbe-fs"}
+
+[lints]
+workspace = true

--- a/crates/unftp-auth-jsonfile/examples/jsonfile_auth.rs
+++ b/crates/unftp-auth-jsonfile/examples/jsonfile_auth.rs
@@ -1,9 +1,11 @@
+//! Shows how to use the JSON file authenticator
+
 use std::sync::Arc;
 use unftp_auth_jsonfile::JsonFileAuthenticator;
 use unftp_sbe_fs::ServerExt;
 
 #[tokio::main(flavor = "current_thread")]
-pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     pretty_env_logger::init();
 
     let authenticator = JsonFileAuthenticator::from_file(String::from("credentials.json"))?;

--- a/crates/unftp-auth-pam/Cargo.toml
+++ b/crates/unftp-auth-pam/Cargo.toml
@@ -29,3 +29,6 @@ pam-auth = { package = "pam", version = "0.7.0" }
 
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["macros"] }
+
+[lints]
+workspace = true

--- a/crates/unftp-auth-rest/Cargo.toml
+++ b/crates/unftp-auth-rest/Cargo.toml
@@ -35,3 +35,6 @@ tracing-attributes = "0.1.27"
 pretty_env_logger = "0.5.0"
 tokio = { version = "1.36.0", features = ["macros"] }
 unftp-sbe-fs = { version="0.2.2", path="../unftp-sbe-fs"}
+
+[lints]
+workspace = true

--- a/crates/unftp-auth-rest/examples/rest.rs
+++ b/crates/unftp-auth-rest/examples/rest.rs
@@ -1,10 +1,12 @@
+//! Shows how to use the REST authenticator
+
 use std::env;
 use std::sync::Arc;
 use unftp_auth_rest::{Builder, RestAuthenticator};
 use unftp_sbe_fs::ServerExt;
 
 #[tokio::main(flavor = "current_thread")]
-pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     pretty_env_logger::init();
 
     let _args: Vec<String> = env::args().collect();

--- a/crates/unftp-auth-rest/src/lib.rs
+++ b/crates/unftp-auth-rest/src/lib.rs
@@ -1,7 +1,3 @@
-#![deny(clippy::all)]
-#![deny(missing_docs)]
-#![forbid(unsafe_code)]
-
 //! This crate provides a [libunftp](https://crates.io/crates/libunftp) `Authenticator`
 //! implementation that authenticates by consuming a JSON REST API.
 //!

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -51,3 +51,5 @@ getrandom = "0.2.12"
 capsicum = { version = "0.3.0", features = ["casper"] }
 capsicum-net = { version = "0.1.0", features = ["tokio"], git = "https://github.com/asomers/capsicum-net", rev = "c6fc574" }
 
+[lints]
+workspace = true

--- a/crates/unftp-sbe-fs/examples/basic.rs
+++ b/crates/unftp-sbe-fs/examples/basic.rs
@@ -1,7 +1,9 @@
+//! The most basic usage
+
 use unftp_sbe_fs::ServerExt;
 
 #[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+async fn main() {
     pretty_env_logger::init();
 
     let addr = "127.0.0.1:2121";

--- a/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
@@ -1,18 +1,16 @@
 //! A libexec helper for cap-std.  It takes an int as $1 which is interpreted as
 //! a file descriptor for an already-connected an authenticated control socket.
 //! Do not invoke this program directly.  Rather, invoke it by examples/cap-ftpd
+#![allow(unsafe_code)]
+use cfg_if::cfg_if;
+use libunftp::Server;
 use std::{
     env,
     os::fd::{FromRawFd, RawFd},
     process::exit,
     sync::{Arc, Mutex},
 };
-
-use cfg_if::cfg_if;
-
 use tokio::net::TcpStream;
-
-use libunftp::Server;
 use unftp_sbe_fs::Filesystem;
 
 mod auth {

--- a/crates/unftp-sbe-fs/examples/cap-ftpd.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd.rs
@@ -4,7 +4,7 @@ use std::{ffi::OsString, path::Path, str::FromStr};
 use unftp_sbe_fs::ServerExt;
 
 #[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+async fn main() {
     let addr = "127.0.0.1:2121";
 
     let args: Vec<String> = std::env::args().collect();

--- a/crates/unftp-sbe-fs/examples/proxyprotocol.rs
+++ b/crates/unftp-sbe-fs/examples/proxyprotocol.rs
@@ -1,7 +1,9 @@
+//! Showing how to use proxy protocol mode.
+
 use unftp_sbe_fs::ServerExt;
 
 #[tokio::main]
-pub async fn main() {
+async fn main() {
     pretty_env_logger::init();
 
     let addr = "127.0.0.1:2121";

--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -56,6 +56,7 @@ pub struct Filesystem {
     root: PathBuf,
 }
 
+/// Metadata for the storage back-end
 #[derive(Debug)]
 pub struct Meta {
     inner: cap_std::fs::Metadata,

--- a/crates/unftp-sbe-gcs/src/lib.rs
+++ b/crates/unftp-sbe-gcs/src/lib.rs
@@ -1,6 +1,3 @@
-#![deny(clippy::all)]
-#![deny(missing_docs)]
-#![forbid(unsafe_code)]
 #![allow(clippy::unnecessary_wraps)]
 
 //! An storage back-end for [libunftp](https://github.com/bolcom/libunftp) that let you store files

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs)]
-
 //! Contains the [`Authenticator`] and [`UserDetail`]
 //! traits that are used to extend libunftp's authentication and user detail storage capabilities.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![deny(clippy::all)]
-#![deny(missing_docs)]
-#![forbid(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/libunftp/0.19.1")]
 
 //! libunftp is an extensible, async, cloud orientated FTP(S) server library.

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -1,4 +1,3 @@
-#![deny(missing_docs)]
 //!
 //! Allows users to listen to events emitted by libunftp.
 //!

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -163,7 +163,6 @@
 //! ```
 //!
 //! [`Server`]: ../struct.Server.html
-#![deny(missing_docs)]
 
 pub(crate) mod error;
 pub use error::{Error, ErrorKind};


### PR DESCRIPTION
Since Rust [1.74.0](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html) lint configuration can be specified in the Cargo.toml file.

I've now done this and also enable lints on workspace level to ensure we don't miss things.