### PR TITLE
Add a UserDetail::read_only method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }
 unftp-sbe-fs = { path = "../libunftp/crates/unftp-sbe-fs"}
 
 [patch.crates-io]
-capsicum = { git = "https://github.com/asomers/capsicum-rs", rev = "24330ee"}
-casper-sys = { git = "https://github.com/asomers/capsicum-rs", rev = "24330ee"}
+capsicum = { git = "https://github.com/asomers/capsicum-rs", rev = "2feefa0"}
+casper-sys = { git = "https://github.com/asomers/capsicum-rs", rev = "2feefa0"}
 
 [lints]
 workspace=true

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -47,6 +47,9 @@ tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.18"
 getrandom = "0.2.12"
 
+[target.'cfg(target_os = "freebsd")'.dependencies]
+capsicum = { version = "0.3.0", features = [] }
+
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 capsicum = { version = "0.3.0", features = ["casper"] }
 capsicum-net = { version = "0.1.0", features = ["tokio"], git = "https://github.com/asomers/capsicum-net", rev = "c6fc574" }

--- a/src/auth/user.rs
+++ b/src/auth/user.rs
@@ -27,6 +27,11 @@ pub trait UserDetail: Send + Sync + Display + Debug {
     fn home(&self) -> Option<&Path> {
         None
     }
+
+    /// Should the user have read-only access, regardless of the Unix file permissions?
+    fn read_only(&self) -> bool {
+        false
+    }
 }
 
 /// DefaultUser is a default implementation of the `UserDetail` trait that doesn't hold any user


### PR DESCRIPTION
If it returns True, then the storage backend should not allow any destructive operations.  Implement this method in the cap-ftpd example for unftp-sbe-fs.

Also, use Capsicum within unftp-sbe-fs, on FreeBSD.  After authenticating a connection, limit the process's rights to mitigate any potential attacks.
