### PR TITLE
unftp-sbe-fs: fix the format of the LIST command

### DIFF
--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -35,8 +35,10 @@ tracing-attributes = "0.1.27"
 async_ftp = "6.0.0"
 async-trait = "0.1.77"
 more-asserts = "0.3.1"
+nix = { version = "0.26.4", default-features = false, features = ["user"] }
 pretty_assertions = "1.4.0"
 pretty_env_logger = "0.5.0"
+regex = "1.10.3"
 rstest = "0.18.2"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"


### PR DESCRIPTION
* Actually implement Metadata::permissions
* Correct some cfg expressions, fixing uid, gid, and nlinks