### PR TITLE
Change the format of LIST for symlinks

### DIFF
--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -21,7 +21,7 @@ readme = "README.md"
 [dependencies]
 async-trait = "0.1.80"
 cfg-if = "1.0"
-cap-std = "2.0"
+cap-std = "3.0"
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
 libunftp = { version = "0.20.1", path = "../../" }

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -21,7 +21,7 @@ readme = "README.md"
 [dependencies]
 async-trait = "0.1.80"
 cfg-if = "1.0"
-cap-std = "3.0"
+cap-std = "3.1"
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
 libunftp = { version = "0.20.1", path = "../../" }

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -34,6 +34,7 @@ tracing-attributes = "0.1.27"
 [dev-dependencies]
 async_ftp = "6.0.0"
 async-trait = "0.1.80"
+chrono = "0.4.0"
 more-asserts = "0.3.1"
 nix = { version = "0.29.0", default-features = false, features = ["user"] }
 pretty_assertions = "1.4.0"

--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -114,7 +114,7 @@ impl<User: UserDetail> StorageBackend<User> for Filesystem {
             .await
             .map_err(|_| Error::from(ErrorKind::PermanentFileNotAvailable))?;
         let target = if fs_meta.is_symlink() {
-            match self.root_fd.read_link(path) {
+            match self.root_fd.read_link_contents(path) {
                 Ok(p) => Some(p),
                 Err(_e) => {
                     // XXX We should really log an error here.  But a logger object is not
@@ -143,7 +143,7 @@ impl<User: UserDetail> StorageBackend<User> for Filesystem {
                 let fullpath = path.join(entry_path.clone());
                 cap_fs::symlink_metadata(self.root_fd.clone(), fullpath.clone()).map_ok(move |meta| {
                     let target = if meta.is_symlink() {
-                        match self.root_fd.read_link(&fullpath) {
+                        match self.root_fd.read_link_contents(&fullpath) {
                             Ok(p) => Some(p),
                             Err(_e) => {
                                 // XXX We should really log an error here.  But a logger object is

--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -40,7 +40,7 @@ use std::{
 use tokio::io::AsyncSeekExt;
 
 #[cfg(unix)]
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use cap_std::fs::{MetadataExt, PermissionsExt};
 
 /// The Filesystem struct is an implementation of the StorageBackend trait that keeps its files
 /// inside a specific root directory on local disk.

--- a/crates/unftp-sbe-fs/tests/main.rs
+++ b/crates/unftp-sbe-fs/tests/main.rs
@@ -333,6 +333,103 @@ mod list {
         }
         assert!(found);
     }
+
+    /// test the exact format of the output for symlinks
+    #[cfg(unix)]
+    #[rstest]
+    #[case::relative(harness(), false)]
+    // Symlinks with absolute paths can be read, too
+    // https://github.com/bytecodealliance/cap-std/issues/353
+    #[case::absolute(harness(), true)]
+    #[awt]
+    #[tokio::test]
+    async fn symlink(
+        #[case]
+        #[future]
+        harness: Harness,
+        #[case] absolute: bool,
+    ) {
+        use regex::Regex;
+        use std::os::unix::fs::MetadataExt;
+
+        // Create a filename in the ftp root that we will look for in the `LIST` output
+        let path = harness.root.join("link");
+        let target = if absolute { "/target" } else { "target" };
+        std::os::unix::fs::symlink(target, &path).unwrap();
+        let md = std::fs::symlink_metadata(&path).unwrap();
+        let uid = md.uid();
+        let gid = md.gid();
+        let link_count = md.nlink();
+        let size = md.len();
+
+        let mut ftp_stream = FtpStream::connect(harness.addr).await.unwrap();
+
+        ensure_login_required(ftp_stream.list(None).await);
+
+        ftp_stream.login("hoi", "jij").await.unwrap();
+        let list = ftp_stream.list(None).await.unwrap();
+        let pat = format!("^l[rwx-]{{9}}\\s+{link_count}\\s+{uid}\\s+{gid}\\s+{size}.*link -> {target}");
+        let re = Regex::new(&pat).unwrap();
+        for entry in list {
+            if entry.contains("link") {
+                assert!(re.is_match(&entry), "\"{entry}\" did not match pattern {re:?}");
+                return;
+            }
+        }
+        panic!("Entry not found");
+    }
+}
+
+mod mdtm {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    /// Get the modification time of a regular file
+    #[rstest]
+    #[awt]
+    #[tokio::test]
+    async fn regular(#[future] harness: Harness) {
+        // Create a filename in the ftp root that we will look for in the `LIST` output
+        let path = harness.root.join("test.txt");
+        let f = std::fs::File::create(path).unwrap();
+        let modified = f.metadata().unwrap().modified().unwrap();
+
+        let mut ftp_stream = FtpStream::connect(harness.addr).await.unwrap();
+
+        ensure_login_required(ftp_stream.list(None).await);
+
+        ftp_stream.login("hoi", "jij").await.unwrap();
+        let r = ftp_stream.mdtm("test.txt").await.unwrap().unwrap();
+        assert_eq!(r.to_rfc2822(), chrono::DateTime::<chrono::Utc>::from(modified).to_rfc2822());
+    }
+
+    /// Get the modification time of a symlink
+    #[rstest]
+    #[case::relative(harness(), false)]
+    #[case::absolute(harness(), true)]
+    #[awt]
+    #[tokio::test]
+    async fn symlink(
+        #[case]
+        #[future]
+        harness: Harness,
+        #[case] absolute: bool,
+    ) {
+        // Create a filename in the ftp root that we will look for in the `LIST` output
+        let path = harness.root.join("link");
+        let target = if absolute { "/target" } else { "target" };
+        std::os::unix::fs::symlink(target, &path).unwrap();
+        let md = std::fs::symlink_metadata(&path).unwrap();
+        let modified = md.modified().unwrap();
+
+        let mut ftp_stream = FtpStream::connect(harness.addr).await.unwrap();
+
+        ensure_login_required(ftp_stream.list(None).await);
+
+        ftp_stream.login("hoi", "jij").await.unwrap();
+        let r = ftp_stream.mdtm("link").await.unwrap().unwrap();
+        assert_eq!(r.to_rfc2822(), chrono::DateTime::<chrono::Utc>::from(modified).to_rfc2822());
+    }
 }
 
 #[rstest]


### PR DESCRIPTION
For symlinks, print the target in the LIST output, like
"link -> target".  That matches the behavior of other ftp servers, like
FreeBSD's ftpd and vsftpd.

See Also https://github.com/bytecodealliance/cap-std/pull/354

Note: this PR must be merged after #504 .  Its tests depend on that one.