### PR TITLE
fix gcs tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run tests
         run: >
           cargo test 
-          --verbose --workspace --exclude 'unftp-sbe-gcs*'
+          --verbose --workspace
       - name: Doc tests
         run: cargo test --doc --workspace
       - name: Build Examples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run tests
         run: >
           cargo test 
-          --verbose --workspace
+          --verbose --workspace --exclude 'unftp-sbe-gcs*'
       - name: Doc tests
         run: cargo test --doc --workspace
       - name: Build Examples


### PR DESCRIPTION
This PR re-enables the GCS tests. By pinning to an older version of the fsouza/fake-gcs-server, which [stopped supporting](https://github.com/fsouza/fake-gcs-server/pull/1017) files ending with / in [v1.43.0](https://github.com/fsouza/fake-gcs-server/releases/tag/v1.43.0)

We should replace this docker-dependent setup with something more robust.

Also reintroducing root_dir setting, which serves as a regression test for https://github.com/bolcom/libunftp/issues/508