### PR TITLE
add ftps_manual to ServerBuilder

### DIFF
--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -21,7 +21,7 @@ readme = "README.md"
 [dependencies]
 async-trait = "0.1.80"
 cfg-if = "1.0"
-cap-std = "2.0"
+cap-std = "3.0"
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
 libunftp = { version = "0.20.1", path = "../../" }

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -21,7 +21,7 @@ readme = "README.md"
 [dependencies]
 async-trait = "0.1.80"
 cfg-if = "1.0"
-cap-std = "3.0"
+cap-std = "3.1"
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
 libunftp = { version = "0.20.1", path = "../../" }

--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -114,7 +114,7 @@ impl<User: UserDetail> StorageBackend<User> for Filesystem {
             .await
             .map_err(|_| Error::from(ErrorKind::PermanentFileNotAvailable))?;
         let target = if fs_meta.is_symlink() {
-            match self.root_fd.read_link(path) {
+            match self.root_fd.read_link_contents(path) {
                 Ok(p) => Some(p),
                 Err(_e) => {
                     // XXX We should really log an error here.  But a logger object is not
@@ -143,7 +143,7 @@ impl<User: UserDetail> StorageBackend<User> for Filesystem {
                 let fullpath = path.join(entry_path.clone());
                 cap_fs::symlink_metadata(self.root_fd.clone(), fullpath.clone()).map_ok(move |meta| {
                     let target = if meta.is_symlink() {
-                        match self.root_fd.read_link(&fullpath) {
+                        match self.root_fd.read_link_contents(&fullpath) {
                             Ok(p) => Some(p),
                             Err(_e) => {
                                 // XXX We should really log an error here.  But a logger object is

--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -40,7 +40,7 @@ use std::{
 use tokio::io::AsyncSeekExt;
 
 #[cfg(unix)]
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use cap_std::fs::{MetadataExt, PermissionsExt};
 
 /// The Filesystem struct is an implementation of the StorageBackend trait that keeps its files
 /// inside a specific root directory on local disk.

--- a/src/server/ftpserver.rs
+++ b/src/server/ftpserver.rs
@@ -259,6 +259,22 @@ where
         self
     }
 
+    /// Enables FTPS by configuring the raw FtpsConfig.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use libunftp::Server;
+    /// use unftp_sbe_fs::ServerExt;
+    ///
+    /// let server = Server::with_fs("/tmp")
+    ///              .ftps_manual(ftps_config);
+    /// ```
+    pub fn ftps_manual<P: Into<PathBuf>>(mut self, config: FtpsConfig) -> Self {
+        self.ftps_mode = config;
+        self
+    }
+
     /// Allows switching on Mutual TLS. For this to work the trust anchors also needs to be set using
     /// the [ftps_trust_store](crate::ServerBuilder::ftps_trust_store) method.
     ///


### PR DESCRIPTION
This change looks small but is actually big. Currently, to update the TLS certificate, you would need to restart the server. With this change, you can make your own rustls ConfigBuilder with a ResolvesServerCert. With this, you can update the certificate automatically on renewal without restarting the server.