### PR TITLE
Make passive port range inclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ pub async fn main() {
     let ftp_home = std::env::temp_dir();
     let server = libunftp::Server::with_fs(ftp_home)
         .greeting("Welcome to my FTP server")
-        .passive_ports(50000..65535)
+        .passive_ports(50000..=65535)
         .build()
         .unwrap();
 

--- a/crates/unftp-sbe-fs/README.md
+++ b/crates/unftp-sbe-fs/README.md
@@ -37,7 +37,7 @@ pub async fn main() {
     let ftp_home = std::env::temp_dir();
     let server = libunftp::Server::with_fs(ftp_home)
         .greeting("Welcome to my FTP server")
-        .passive_ports(50000..65535)
+        .passive_ports(50000..=65535)
         .build()
         .unwrap();
 

--- a/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
+++ b/crates/unftp-sbe-fs/examples/cap-ftpd-worker.rs
@@ -176,7 +176,7 @@ cfg_if! {
         use std::{
             io,
             net::IpAddr,
-            ops::Range
+            ops::RangeInclusive
         };
         use async_trait::async_trait;
         use capsicum::casper::Casper;
@@ -196,7 +196,7 @@ cfg_if! {
 
         #[async_trait]
         impl libunftp::options::Binder for CapBinder {
-            async fn bind(&mut self, local_addr: IpAddr, passive_ports: Range<u16>) -> io::Result<TcpSocket> {
+            async fn bind(&mut self, local_addr: IpAddr, passive_ports: RangeInclusive<u16>) -> io::Result<TcpSocket> {
                 const BIND_RETRIES: u8 = 10;
 
                 for _ in 1..BIND_RETRIES {

--- a/crates/unftp-sbe-fs/examples/proxyprotocol.rs
+++ b/crates/unftp-sbe-fs/examples/proxyprotocol.rs
@@ -9,7 +9,7 @@ async fn main() {
     let addr = "127.0.0.1:2121";
     let server = libunftp::Server::with_fs(std::env::temp_dir())
         .proxy_protocol_mode(2121)
-        .passive_ports(5000..5005)
+        .passive_ports(5000..=5005)
         .build()
         .unwrap();
 

--- a/crates/unftp-sbe-fs/src/lib.rs
+++ b/crates/unftp-sbe-fs/src/lib.rs
@@ -11,7 +11,7 @@
 //!     let ftp_home = std::env::temp_dir();
 //!     let server = libunftp::Server::with_fs(ftp_home)
 //!         .greeting("Welcome to my FTP server")
-//!         .passive_ports(50000..65535)
+//!         .passive_ports(50000..=65535)
 //!         .build()
 //!         .unwrap();
 //!

--- a/crates/unftp-sbe-gcs/README.md
+++ b/crates/unftp-sbe-gcs/README.md
@@ -31,7 +31,7 @@ use std::path::PathBuf;
 pub async fn main() {
     let server = Server::with_gcs("my-bucket", PathBuf::from("/unftp"), AuthMethod::WorkloadIdentity(None))
         .greeting("Welcome to my FTP server")
-        .passive_ports(50000..65535)
+        .passive_ports(50000..=65535)
         .build()
         .unwrap();
 
@@ -52,7 +52,7 @@ pub async fn main() {
         Box::new(move || CloudStorage::with_bucket_root("my-bucket", PathBuf::from("/ftp-root"), AuthMethod::WorkloadIdentity(None)))
     )
         .greeting("Welcome to my FTP server")
-        .passive_ports(50000..65535)
+        .passive_ports(50000..=65535)
         .build()
         .unwrap();
 

--- a/crates/unftp-sbe-gcs/src/lib.rs
+++ b/crates/unftp-sbe-gcs/src/lib.rs
@@ -25,7 +25,7 @@
 //! pub async fn main() {
 //!     let server = Server::with_gcs("my-bucket", PathBuf::from("/unftp"), AuthMethod::WorkloadIdentity(None))
 //!       .greeting("Welcome to my FTP server")
-//!       .passive_ports(50000..65535)
+//!       .passive_ports(50000..=65535)
 //!       .build()
 //!       .unwrap();
 //!
@@ -47,7 +47,7 @@
 //!         Box::new(move || CloudStorage::with_bucket_root("my-bucket", PathBuf::from("/ftp-root"), AuthMethod::WorkloadIdentity(None)))
 //!       )
 //!       .greeting("Welcome to my FTP server")
-//!       .passive_ports(50000..65535)
+//!       .passive_ports(50000..=65535)
 //!       .build()
 //!       .unwrap();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //!     let ftp_home = std::env::temp_dir();
 //!     let server = libunftp::Server::with_fs(ftp_home)
 //!         .greeting("Welcome to my FTP server")
-//!         .passive_ports(50000..65535)
+//!         .passive_ports(50000..=65535)
 //!         .build()
 //!         .unwrap();
 //!

--- a/src/server/controlchan/commands/pasv.rs
+++ b/src/server/controlchan/commands/pasv.rs
@@ -23,7 +23,7 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use std::{io, net::SocketAddr, ops::Range};
+use std::{io, net::SocketAddr, ops::RangeInclusive};
 use std::{
     net::{IpAddr, Ipv4Addr},
     time::Duration,
@@ -42,8 +42,8 @@ impl Pasv {
     }
 
     #[tracing_attributes::instrument]
-    fn try_port_range(local_addr: IpAddr, passive_ports: Range<u16>) -> io::Result<TcpSocket> {
-        let rng_length = passive_ports.end - passive_ports.start + 1;
+    fn try_port_range(local_addr: IpAddr, passive_ports: RangeInclusive<u16>) -> io::Result<TcpSocket> {
+        let rng_length = passive_ports.end() - passive_ports.start() + 1;
 
         let mut socket: io::Result<TcpSocket> = Err(io::Error::new(io::ErrorKind::InvalidInput, "Bind retries cannot be 0"));
 
@@ -54,7 +54,7 @@ impl Pasv {
                 u32::from_ne_bytes(data)
             };
 
-            let port = random_u32 % rng_length as u32 + passive_ports.start as u32;
+            let port = random_u32 % rng_length as u32 + *passive_ports.start() as u32;
             let s = TcpSocket::new_v4()?;
             s.set_reuseaddr(true)?;
             if s.bind(std::net::SocketAddr::new(local_addr, port as u16)).is_ok() {

--- a/src/server/controlchan/commands/user.rs
+++ b/src/server/controlchan/commands/user.rs
@@ -242,7 +242,7 @@ mod tests {
                 session: session_arc,
                 authenticator: auther,
                 tls_configured: true,
-                passive_ports: Default::default(),
+                passive_ports: 0..=0,
                 passive_host: Default::default(),
                 tx_control_chan: tx,
                 local_addr: "127.0.0.1:8080".parse().unwrap(),

--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -33,7 +33,7 @@ use crate::{
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
 use rustls::ServerConnection;
-use std::{net::SocketAddr, ops::Range, sync::Arc, time::Duration};
+use std::{net::SocketAddr, ops::RangeInclusive, sync::Arc, time::Duration};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::TcpStream,
@@ -58,7 +58,7 @@ where
     pub storage: Storage,
     pub greeting: &'static str,
     pub authenticator: Arc<dyn Authenticator<User>>,
-    pub passive_ports: Range<u16>,
+    pub passive_ports: RangeInclusive<u16>,
     pub passive_host: PassiveHost,
     pub ftps_config: FtpsConfig,
     pub collect_metrics: bool,
@@ -330,7 +330,7 @@ where
     session: SharedSession<Storage, User>,
     authenticator: Arc<dyn Authenticator<User>>,
     tls_configured: bool,
-    passive_ports: Range<u16>,
+    passive_ports: RangeInclusive<u16>,
     passive_host: PassiveHost,
     tx_control_chan: Sender<ControlChanMsg>,
     local_addr: SocketAddr,

--- a/src/server/controlchan/handler.rs
+++ b/src/server/controlchan/handler.rs
@@ -10,7 +10,7 @@ use crate::{
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use std::{ops::Range, sync::Arc};
+use std::{ops::RangeInclusive, sync::Arc};
 use tokio::sync::mpsc::Sender;
 
 // Common interface for all handlers of `Commands`
@@ -36,7 +36,7 @@ where
     pub session: SharedSession<Storage, User>,
     pub authenticator: Arc<dyn Authenticator<User>>,
     pub tls_configured: bool,
-    pub passive_ports: Range<u16>,
+    pub passive_ports: RangeInclusive<u16>,
     pub passive_host: PassiveHost,
     pub tx_control_chan: Sender<ControlChanMsg>,
     pub local_addr: std::net::SocketAddr,

--- a/src/server/ftpserver.rs
+++ b/src/server/ftpserver.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 use options::{PassiveHost, DEFAULT_GREETING, DEFAULT_IDLE_SESSION_TIMEOUT_SECS};
 use slog::*;
-use std::{ffi::OsString, fmt::Debug, future::Future, net::SocketAddr, ops::Range, path::PathBuf, pin::Pin, sync::Arc, time::Duration};
+use std::{ffi::OsString, fmt::Debug, future::Future, net::SocketAddr, ops::RangeInclusive, path::PathBuf, pin::Pin, sync::Arc, time::Duration};
 
 /// An instance of an FTP(S) server. It aggregates an [`Authenticator`](crate::auth::Authenticator)
 /// implementation that will be used for authentication, and a [`StorageBackend`](crate::storage::StorageBackend)
@@ -59,7 +59,7 @@ where
     authenticator: Arc<dyn Authenticator<User>>,
     data_listener: Arc<dyn DataListener>,
     presence_listener: Arc<dyn PresenceListener>,
-    passive_ports: Range<u16>,
+    passive_ports: RangeInclusive<u16>,
     passive_host: PassiveHost,
     collect_metrics: bool,
     ftps_mode: FtpsConfig,
@@ -88,7 +88,7 @@ where
     authenticator: Arc<dyn Authenticator<User>>,
     data_listener: Arc<dyn DataListener>,
     presence_listener: Arc<dyn PresenceListener>,
-    passive_ports: Range<u16>,
+    passive_ports: RangeInclusive<u16>,
     passive_host: PassiveHost,
     collect_metrics: bool,
     ftps_mode: FtpsConfig,
@@ -490,13 +490,13 @@ where
     ///
     /// // Use it in a builder-like pattern:
     /// let builder = Server::with_fs("/tmp")
-    ///              .passive_ports(49152..65535);
+    ///              .passive_ports(49152..=65535);
     ///
     /// // Or instead if you prefer:
     /// let mut builder = Server::with_fs("/tmp");
-    /// builder.passive_ports(49152..65535);
+    /// builder.passive_ports(49152..=65535);
     /// ```
-    pub fn passive_ports(mut self, range: Range<u16>) -> Self {
+    pub fn passive_ports(mut self, range: RangeInclusive<u16>) -> Self {
         self.passive_ports = range;
         self
     }

--- a/src/server/ftpserver/chosen.rs
+++ b/src/server/ftpserver/chosen.rs
@@ -11,7 +11,8 @@ use crate::{
     server::tls::FtpsConfig,
     storage::StorageBackend,
 };
-use std::{ops::Range, sync::Arc, time::Duration};
+use std::ops::RangeInclusive;
+use std::{sync::Arc, time::Duration};
 
 // Holds the options the libunftp user opted for.
 pub struct OptionsHolder<Storage, User>
@@ -22,7 +23,7 @@ where
     pub storage: Arc<dyn (Fn() -> Storage) + Send + Sync>,
     pub greeting: &'static str,
     pub authenticator: Arc<dyn Authenticator<User>>,
-    pub passive_ports: Range<u16>,
+    pub passive_ports: RangeInclusive<u16>,
     pub passive_host: PassiveHost,
     pub ftps_config: FtpsConfig,
     pub collect_metrics: bool,

--- a/src/server/ftpserver/options.rs
+++ b/src/server/ftpserver/options.rs
@@ -2,13 +2,13 @@
 
 use async_trait::async_trait;
 use bitflags::bitflags;
+use std::ops::RangeInclusive;
 use std::time::Duration;
 use std::{
     fmt::Formatter,
     fmt::{self, Debug, Display},
     io,
     net::{IpAddr, Ipv4Addr},
-    ops::Range,
 };
 use tokio::net::TcpSocket;
 
@@ -17,7 +17,7 @@ use tokio::net::TcpSocket;
 pub(crate) const DEFAULT_GREETING: &str = "Welcome to the libunftp FTP server";
 pub(crate) const DEFAULT_IDLE_SESSION_TIMEOUT_SECS: u64 = 600;
 pub(crate) const DEFAULT_PASSIVE_HOST: PassiveHost = PassiveHost::FromConnection;
-pub(crate) const DEFAULT_PASSIVE_PORTS: Range<u16> = 49152..65535;
+pub(crate) const DEFAULT_PASSIVE_PORTS: RangeInclusive<u16> = 49152..=65535;
 pub(crate) const DEFAULT_FTPS_REQUIRE: FtpsRequired = FtpsRequired::None;
 pub(crate) const DEFAULT_FTPS_TRUST_STORE: &str = "./trusted.pem";
 
@@ -26,7 +26,7 @@ pub(crate) const DEFAULT_FTPS_TRUST_STORE: &str = "./trusted.pem";
 pub trait Binder: Debug + Send {
     /// Create a [`tokio::net::TcpSocket`] and bind it to the given address, with a port in the
     /// given range.
-    async fn bind(&mut self, local_addr: IpAddr, passive_ports: Range<u16>) -> io::Result<TcpSocket>;
+    async fn bind(&mut self, local_addr: IpAddr, passive_ports: RangeInclusive<u16>) -> io::Result<TcpSocket>;
 }
 
 /// The option to [ServerBuilder::passive_host](crate::ServerBuilder::passive_host). It allows the user to specify how the IP address


### PR DESCRIPTION
Today, the passive port range is stored in a [half-open](https://doc.rust-lang.org/std/ops/struct.Range.html) `Range` despite being used internally as a [`RangeInclusive`](https://doc.rust-lang.org/std/ops/struct.RangeInclusive.html). I think this behavior can be confusing to users who are used to `a..b` meaning `a` up to **but not including** `b`. It was for me, at least, when I deployed a little application using this library and had to specify which ports to expose to the cloud provider and missed the upper port.