### PR TITLE
Implement 550 for RNFR command

### DIFF
--- a/src/server/controlchan/commands/rnfr.rs
+++ b/src/server/controlchan/commands/rnfr.rs
@@ -2,15 +2,19 @@
 
 use crate::{
     auth::UserDetail,
-    server::controlchan::{
-        Reply, ReplyCode,
-        error::ControlChanError,
-        handler::{CommandContext, CommandHandler},
+    server::{
+        ControlChanMsg,
+        controlchan::{
+            Reply, ReplyCode,
+            error::ControlChanError,
+            handler::{CommandContext, CommandHandler},
+        },
     },
     storage::{Metadata, StorageBackend},
 };
 use async_trait::async_trait;
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
+use tokio::sync::mpsc::Sender;
 
 #[derive(Debug)]
 pub struct Rnfr {
@@ -32,8 +36,39 @@ where
 {
     #[tracing_attributes::instrument]
     async fn handle(&self, args: CommandContext<Storage, User>) -> Result<Reply, ControlChanError> {
-        let mut session = args.session.lock().await;
-        session.rename_from = Some(session.cwd.join(self.path.clone()));
-        Ok(Reply::new(ReplyCode::FileActionPending, "Tell me, what would you like the new name to be?"))
+        let session = args.session.lock().await;
+        let user = session.user.clone();
+        let storage = Arc::clone(&session.storage);
+        let path = session.cwd.join(self.path.clone());
+        let tx_success: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let tx_fail: Sender<ControlChanMsg> = args.tx_control_chan.clone();
+        let logger = args.logger;
+        drop(session);
+
+        let session = args.session;
+
+        tokio::spawn(async move {
+            let mut session = session.lock().await;
+            match storage.metadata((*user).as_ref().unwrap(), &path).await {
+                Ok(_) => {
+                    session.rename_from = Some(path);
+                    if let Err(err) = tx_success
+                        .send(ControlChanMsg::CommandChannelReply(Reply::new_with_string(
+                            ReplyCode::FileActionPending,
+                            "Tell me, what would you like the new name to be?".to_string(),
+                        )))
+                        .await
+                    {
+                        slog::warn!(logger, "RNFR: Could not send internal message to notify of RNFR success: {}", err);
+                    }
+                }
+                Err(err) => {
+                    if let Err(err) = tx_fail.send(ControlChanMsg::StorageError(err)).await {
+                        slog::warn!(logger, "RNFR: Could not send internal message to notify of RNFR failure: {}", err);
+                    }
+                }
+            }
+        });
+        Ok(Reply::none())
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use lazy_static::*;
 use libunftp::auth::{AuthenticationError, Authenticator, Credentials, DefaultUser};
 use libunftp::options::{FailedLoginsBlock, FailedLoginsPolicy};
+use std::io::Error;
+use std::net::SocketAddr;
 use std::sync::Arc;
+use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use unftp_sbe_fs::ServerExt;
 
@@ -46,6 +49,68 @@ pub async fn finalize() {
         } else {
             drop(lock);
             break;
+        }
+    }
+}
+
+pub async fn read_from_server<'a>(buffer: &'a mut [u8], stream: &TcpStream) -> &'a str {
+    loop {
+        stream.readable().await.unwrap();
+        let n = match stream.try_read(buffer) {
+            Ok(n) => n,
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                continue;
+            }
+            Err(e) => panic!("{}", e),
+        };
+        return std::str::from_utf8(&buffer[0..n]).unwrap();
+    }
+}
+
+pub async fn send_to_server(buffer: &str, stream: &TcpStream) {
+    loop {
+        stream.writable().await.unwrap();
+
+        match stream.try_write(buffer.as_bytes()) {
+            Ok(_) => break,
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                continue;
+            }
+            Err(e) => panic!("{}", e),
+        };
+    }
+}
+
+pub async fn tcp_connect() -> Result<TcpStream, Error> {
+    let mut errcount: i32 = 0;
+    loop {
+        match TcpStream::connect("127.0.0.1:2150").await {
+            Ok(s) => return Ok(s),
+            Err(e) => {
+                if errcount > 2 {
+                    return Err(e);
+                }
+                errcount += 1;
+                tokio::time::sleep(std::time::Duration::new(1, 0)).await;
+                continue;
+            }
+        }
+    }
+}
+
+pub async fn tcp_pasv_connect(addr: SocketAddr) -> Result<TcpStream, Error> {
+    let mut errcount: i32 = 0;
+    loop {
+        match TcpStream::connect(addr).await {
+            Ok(s) => return Ok(s),
+            Err(e) => {
+                if errcount > 2 {
+                    return Err(e);
+                }
+                errcount += 1;
+                tokio::time::sleep(std::time::Duration::new(1, 0)).await;
+                continue;
+            }
         }
     }
 }

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -1,0 +1,92 @@
+#![allow(missing_docs)]
+
+pub mod common;
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use common::{read_from_server, send_to_server, tcp_connect};
+use tokio::io::AsyncWriteExt;
+
+use crate::common::tcp_pasv_connect;
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_rename() {
+    common::initialize().await;
+
+    let stream = tcp_connect().await.unwrap();
+
+    let mut buffer = vec![0_u8; 1024];
+
+    assert_eq!(read_from_server(&mut buffer, &stream).await, "220 Welcome test\r\n");
+
+    send_to_server("USER test\r\n", &stream).await;
+    assert_eq!(read_from_server(&mut buffer, &stream).await, "331 Password Required\r\n");
+
+    send_to_server("PASS test\r\n", &stream).await;
+    assert_eq!(read_from_server(&mut buffer, &stream).await, "230 User logged in, proceed\r\n");
+
+    send_to_server("TYPE I\r\n", &stream).await;
+    assert_eq!(read_from_server(&mut buffer, &stream).await, "200 Always in binary mode\r\n");
+
+    send_to_server("PASV\r\n", &stream).await;
+    let resp = read_from_server(&mut buffer, &stream).await;
+    assert!(resp.starts_with("227 Entering Passive Mode"));
+    let addr = parse_pasv(resp).unwrap();
+    assert_eq!(Ok(addr.ip()), "127.0.0.1".parse());
+    assert_ne!(addr.port(), 0);
+
+    send_to_server("STOR test.txt\r\n", &stream).await;
+    assert_eq!(read_from_server(&mut buffer, &stream).await, "150 Ready to receive data\r\n");
+
+    let mut bin_stream = tcp_pasv_connect(addr).await.unwrap();
+    send_to_server("testcontent", &bin_stream).await;
+    bin_stream.shutdown().await.unwrap();
+    drop(bin_stream);
+
+    assert_eq!(read_from_server(&mut buffer, &stream).await, "226 File successfully written\r\n");
+
+    send_to_server("RNFR test.txt\r\n", &stream).await;
+    assert_eq!(
+        read_from_server(&mut buffer, &stream).await,
+        "350 Tell me, what would you like the new name to be?\r\n"
+    );
+
+    send_to_server("RNTO foo\r\n", &stream).await;
+    assert_eq!(read_from_server(&mut buffer, &stream).await, "250 Renamed\r\n");
+
+    common::finalize().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_rename_no_file() {
+    common::initialize().await;
+
+    let stream = tcp_connect().await.unwrap();
+
+    let mut buffer = vec![0_u8; 1024];
+
+    assert_eq!(read_from_server(&mut buffer, &stream).await, "220 Welcome test\r\n");
+
+    send_to_server("USER test\r\n", &stream).await;
+    assert_eq!(read_from_server(&mut buffer, &stream).await, "331 Password Required\r\n");
+
+    send_to_server("PASS test\r\n", &stream).await;
+    assert_eq!(read_from_server(&mut buffer, &stream).await, "230 User logged in, proceed\r\n");
+
+    send_to_server("RNFR test.txt\r\n", &stream).await;
+    assert_eq!(read_from_server(&mut buffer, &stream).await, "550 File not found\r\n");
+
+    common::finalize().await;
+}
+
+/// Returns `(ip, port)` for a standard FTP `227` reply line.
+fn parse_pasv(line: &str) -> Result<SocketAddr, &'static str> {
+    let body = line.split_once('(').and_then(|(_, rest)| rest.split_once(')')).ok_or("bad format")?.0;
+    let nums: Vec<u8> = body.split(',').filter_map(|s| s.trim().parse().ok()).collect();
+    if nums.len() != 6 {
+        return Err("need 6 numbers");
+    }
+    let port = u16::from(nums[4]) * 256 + u16::from(nums[5]);
+
+    Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(nums[0], nums[1], nums[2], nums[3])), port))
+}


### PR DESCRIPTION
Some FTP clients expect the server to indicate whether a file exists when they send the RNFR command. If it does, they expect a 350 (which currently happens). If it doesn't, the expect a 550 ("Requested action not taken") to indicate the file isn't available.

This adds this behaviour to the RNFR command and adds tests for both behaviours. I moved some functions from pass_security.rs to common.rs where I re-use them in the new tests.

I came across this because my scanner complained that the file I'm trying to scan already exists and I noticed it was sending RNFR and got confused by the 350 reply.

I decided to use the metadata command to check if a file exists since it seemed to be the best candidate. Please let me know if there's anything I can improve about the PR.

I ran `make pr-prep`, but I think the current failures are unrelated to my changes so I didn't fix them to keep the commit clean.