### PR TITLE
Split Authenticators from the Subject Resolving (UserDetail Providing) concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### Upcoming release
+
+- **BREAKING**: Refactored `Authenticator` trait to be non-generic and return `Principal` instead of a generic `User` type. This decouples authentication (verifying credentials) from user detail retrieval (obtaining full user information).
+- Introduced `Principal` struct representing an authenticated user's identity (username). This is the minimal information returned by authentication.
+- Introduced `UserDetailProvider` trait to convert a `Principal` into a full `UserDetail` implementation. This allows authentication and user detail lookup to be separated.
+- Introduced `AuthenticationPipeline` struct that combines an `Authenticator` and a `UserDetailProvider` to provide a complete authentication flow.
+- Added `DefaultUserDetailProvider` implementation that returns `DefaultUser` for convenience.
+- **BREAKING**: Updated all `unftp-auth-*` crates (`unftp-auth-jsonfile`, `unftp-auth-pam`, `unftp-auth-rest`) to use the new non-generic `Authenticator` trait.
+- Updated all examples and tests to use the new authentication pattern.
+
 ### libunftp 0.22.0
 
 - Compile against Rust 1.92.0 in CI

--- a/crates/unftp-auth-jsonfile/tests/main.rs
+++ b/crates/unftp-auth-jsonfile/tests/main.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use libunftp::auth::{Authenticator, DefaultUser};
+use libunftp::auth::Authenticator;
 use std::path::PathBuf;
 use unftp_auth_jsonfile::JsonFileAuthenticator;
 
@@ -17,7 +17,7 @@ async fn credentials_from_file_type_plain() {
     let path = input_file_path("cred.json".to_string());
 
     let json_auther = JsonFileAuthenticator::from_file(path).unwrap();
-    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap(), DefaultUser);
+    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap().username, "testuser");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -25,7 +25,7 @@ async fn credentials_from_file_type_gzipped() {
     let path = input_file_path("cred.json.gz".to_string());
 
     let json_auther = JsonFileAuthenticator::from_file(path).unwrap();
-    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap(), DefaultUser);
+    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap().username, "testuser");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -33,5 +33,5 @@ async fn credentials_from_file_type_gzipped_base64() {
     let path = input_file_path("cred.json.gz.b64".to_string());
 
     let json_auther = JsonFileAuthenticator::from_file(path).unwrap();
-    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap(), DefaultUser);
+    assert_eq!(json_auther.authenticate("testuser", &"testpassword".into()).await.unwrap().username, "testuser");
 }

--- a/crates/unftp-sbe-gcs/src/lib.rs
+++ b/crates/unftp-sbe-gcs/src/lib.rs
@@ -37,13 +37,14 @@
 //! constructors of `Server` e.g.
 //!
 //! ```no_run
-//! use libunftp::Server;
+//! use libunftp::ServerBuilder;
 //! use unftp_sbe_gcs::{CloudStorage, options::AuthMethod};
 //! use std::path::PathBuf;
+//! use std::sync::Arc;
 //!
 //! #[tokio::main]
 //! pub async fn main() {
-//!     let server = libunftp::Server::new(
+//!     let server = libunftp::ServerBuilder::new(
 //!         Box::new(move || CloudStorage::with_bucket_root("my-bucket", PathBuf::from("/ftp-root"), AuthMethod::WorkloadIdentity(None)))
 //!       )
 //!       .greeting("Welcome to my FTP server")

--- a/src/auth/anonymous.rs
+++ b/src/auth/anonymous.rs
@@ -11,10 +11,10 @@ use async_trait::async_trait;
 /// ```rust
 /// # #[tokio::main]
 /// # async fn main() {
-/// use libunftp::auth::{Authenticator, AnonymousAuthenticator, DefaultUser};
+/// use libunftp::auth::{Authenticator, AnonymousAuthenticator, Principal};
 ///
 /// let my_auth = AnonymousAuthenticator{};
-/// assert_eq!(my_auth.authenticate("Finn", &"I ❤️ PB".into()).await.unwrap(), DefaultUser{});
+/// assert_eq!(my_auth.authenticate("Finn", &"I ❤️ PB".into()).await.unwrap().username, "Finn");
 /// # }
 /// ```
 ///
@@ -22,11 +22,13 @@ use async_trait::async_trait;
 pub struct AnonymousAuthenticator;
 
 #[async_trait]
-impl Authenticator<DefaultUser> for AnonymousAuthenticator {
+impl Authenticator for AnonymousAuthenticator {
     #[allow(clippy::type_complexity)]
     #[tracing_attributes::instrument]
-    async fn authenticate(&self, _username: &str, _password: &Credentials) -> Result<DefaultUser, AuthenticationError> {
-        Ok(DefaultUser {})
+    async fn authenticate(&self, username: &str, _password: &Credentials) -> Result<Principal, AuthenticationError> {
+        Ok(Principal {
+            username: username.to_string(),
+        })
     }
 
     async fn cert_auth_sufficient(&self, _username: &str) -> bool {

--- a/src/auth/authenticator.rs
+++ b/src/auth/authenticator.rs
@@ -1,6 +1,5 @@
 //! The service provider interface (SPI) for auth
 
-use super::UserDetail;
 use crate::BoxError;
 
 use async_trait::async_trait;
@@ -9,12 +8,17 @@ use thiserror::Error;
 
 /// Defines the requirements for Authentication implementations
 #[async_trait]
-pub trait Authenticator<User>: Sync + Send + Debug
-where
-    User: UserDetail,
-{
+pub trait Authenticator: Sync + Send + Debug {
     /// Authenticate the given user with the given credentials.
-    async fn authenticate(&self, username: &str, creds: &Credentials) -> Result<User, AuthenticationError>;
+    ///
+    /// Returns a [`Principal`] representing the authenticated user identity.
+    /// To obtain full user details, use a [`UserDetailProvider`] to convert the `Principal`
+    /// into a full [`UserDetail`] implementation.
+    ///
+    /// [`Principal`]: struct.Principal.html
+    /// [`UserDetailProvider`]: ../trait.UserDetailProvider.html
+    /// [`UserDetail`]: ../trait.UserDetail.html
+    async fn authenticate(&self, username: &str, creds: &Credentials) -> Result<Principal, AuthenticationError>;
 
     /// Tells whether its OK to not ask for a password when a valid client cert
     /// was presented.

--- a/src/auth/pipeline.rs
+++ b/src/auth/pipeline.rs
@@ -1,0 +1,98 @@
+//! Authentication pipeline that combines authentication and user detail retrieval.
+
+use super::{
+    authenticator::{AuthenticationError, Authenticator, Credentials},
+    user::{UserDetail, UserDetailProvider},
+};
+use std::fmt::Debug;
+use std::sync::Arc;
+
+/// Combines an [`Authenticator`] and a [`UserDetailProvider`] to provide a complete
+/// authentication flow that returns a full [`UserDetail`] implementation.
+///
+/// This pipeline encapsulates the two-step process:
+/// 1. Authenticate the user (returns `Principal`)
+/// 2. Retrieve user details (converts `Principal` to `User: UserDetail`)
+///
+/// # Example
+///
+/// ```rust
+/// use libunftp::auth::{AuthenticationPipeline, Authenticator, UserDetailProvider, Principal, DefaultUser};
+/// use async_trait::async_trait;
+/// use std::sync::Arc;
+///
+/// // Assuming you have a non-generic Authenticator and a UserDetailProvider
+/// // let authenticator = Arc::new(MyAuthenticator);
+/// // let user_provider = Arc::new(MyUserDetailProvider);
+/// // let pipeline = AuthenticationPipeline::new(authenticator, user_provider);
+/// ```
+///
+/// [`Authenticator`]: trait.Authenticator.html
+/// [`UserDetailProvider`]: trait.UserDetailProvider.html
+/// [`UserDetail`]: trait.UserDetail.html
+#[derive(Debug)]
+pub struct AuthenticationPipeline<User>
+where
+    User: UserDetail,
+{
+    authenticator: Arc<dyn Authenticator + Send + Sync>,
+    user_provider: Arc<dyn UserDetailProvider<User = User> + Send + Sync>,
+}
+
+impl<User> AuthenticationPipeline<User>
+where
+    User: UserDetail,
+{
+    /// Creates a new `AuthenticationPipeline` combining the given authenticator and user provider.
+    ///
+    /// The authenticator returns a `Principal` and the provider converts it to a full `UserDetail`.
+    pub fn new(authenticator: Arc<dyn Authenticator + Send + Sync>, user_provider: Arc<dyn UserDetailProvider<User = User> + Send + Sync>) -> Self {
+        Self { authenticator, user_provider }
+    }
+
+    /// Returns a reference to the underlying authenticator.
+    pub fn authenticator(&self) -> &Arc<dyn Authenticator + Send + Sync> {
+        &self.authenticator
+    }
+
+    /// Returns a reference to the underlying user detail provider.
+    pub fn user_provider(&self) -> &Arc<dyn UserDetailProvider<User = User> + Send + Sync> {
+        &self.user_provider
+    }
+
+    /// Authenticates the user and returns the full user detail.
+    ///
+    /// This method will:
+    /// 1. Authenticate the user (to verify credentials and get a `Principal`)
+    /// 2. Use the provider to convert the authenticated `Principal` to a full `UserDetail`
+    ///
+    /// # Errors
+    ///
+    /// Returns `AuthenticationError` if authentication fails or if user detail retrieval fails.
+    pub async fn authenticate_and_get_user(&self, username: &str, creds: &Credentials) -> Result<User, AuthenticationError> {
+        // Authenticate to get Principal
+        let principal = self.authenticator.authenticate(username, creds).await?;
+
+        // Use the provider to convert Principal to User
+        self.user_provider.provide_user_detail(&principal).await.map_err(|e| match e {
+            super::user::UserDetailError::UserNotFound { .. } => AuthenticationError::BadUser,
+            super::user::UserDetailError::Generic(msg) => AuthenticationError::new(msg),
+            super::user::UserDetailError::ImplPropagated(msg, source) => AuthenticationError::ImplPropagated(msg, source),
+        })
+    }
+
+    /// Tells whether its OK to not ask for a password when a valid client cert
+    /// was presented.
+    ///
+    /// This delegates to the underlying authenticator's `cert_auth_sufficient` method.
+    pub async fn cert_auth_sufficient(&self, username: &str) -> bool {
+        self.authenticator.cert_auth_sufficient(username).await
+    }
+
+    /// Returns the name of the authenticator.
+    ///
+    /// This delegates to the underlying authenticator's `name` method.
+    pub fn name(&self) -> &str {
+        self.authenticator.name()
+    }
+}

--- a/src/auth/user.rs
+++ b/src/auth/user.rs
@@ -152,3 +152,39 @@ impl Display for DefaultUser {
         write!(f, "DefaultUser")
     }
 }
+
+/// A default implementation of [`UserDetailProvider`] that converts any [`Principal`] to a [`DefaultUser`].
+///
+/// This provider is useful when you don't need any additional user information beyond the authenticated
+/// username. It simply returns a [`DefaultUser`] for any principal.
+///
+/// # Example
+///
+/// ```rust
+/// # #[tokio::main]
+/// # async fn main() {
+/// use libunftp::auth::{DefaultUserDetailProvider, Principal, UserDetailProvider};
+///
+/// let provider = DefaultUserDetailProvider;
+/// let principal = Principal {
+///     username: "alice".to_string(),
+/// };
+/// let user = provider.provide_user_detail(&principal).await.unwrap();
+/// # }
+/// ```
+///
+/// [`UserDetailProvider`]: trait.UserDetailProvider.html
+/// [`Principal`]: ../struct.Principal.html
+/// [`DefaultUser`]: struct.DefaultUser.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DefaultUserDetailProvider;
+
+#[async_trait]
+impl UserDetailProvider for DefaultUserDetailProvider {
+    type User = DefaultUser;
+
+    async fn provide_user_detail(&self, _principal: &Principal) -> Result<DefaultUser, UserDetailError> {
+        // DefaultUser doesn't hold any information, so we can just return it for any principal
+        Ok(DefaultUser)
+    }
+}

--- a/src/server/controlchan/commands/pass.rs
+++ b/src/server/controlchan/commands/pass.rs
@@ -66,7 +66,7 @@ where
                 };
                 let tx: Sender<ControlChanMsg> = args.tx_control_chan.clone();
 
-                let auther = args.authenticator.clone();
+                let auth_pipeline = args.auth_pipeline.clone();
 
                 // without this, the REST authenticator hangs when
                 // performing a http call through Hyper
@@ -79,7 +79,7 @@ where
                 let failed_logins = session.failed_logins.clone();
                 let source_ip = session.source.ip();
                 tokio::spawn(async move {
-                    let msg = match auther.authenticate(&username, &creds).await {
+                    let msg = match auth_pipeline.authenticate_and_get_user(&username, &creds).await {
                         Ok(user) => {
                             let is_locked = match failed_logins {
                                 Some(failed_logins) => {

--- a/src/server/controlchan/commands/stat.rs
+++ b/src/server/controlchan/commands/stat.rs
@@ -61,7 +61,7 @@ where
                     "server status:".to_string(),
                     format!("powered by libunftp: {}", env!("CARGO_PKG_VERSION")),
                     format!("sbe: {}", session.storage.name()),
-                    format!("authenticator: {}", args.authenticator.name()),
+                    format!("authenticator: {}", args.auth_pipeline.name()),
                     format!("user: {}", session.username.as_ref().unwrap()),
                     format!("client addr: {}", session.source),
                     format!("ftps configured: {}", args.tls_configured),

--- a/src/server/controlchan/control_loop.rs
+++ b/src/server/controlchan/control_loop.rs
@@ -1,5 +1,5 @@
 use crate::{
-    auth::{Authenticator, UserDetail},
+    auth::{AuthenticationPipeline, UserDetail},
     metrics::MetricsMiddleware,
     notification::{DataListener, PresenceListener},
     options::ActivePassiveMode,
@@ -57,7 +57,7 @@ where
 {
     pub storage: Storage,
     pub greeting: &'static str,
-    pub authenticator: Arc<dyn Authenticator<User>>,
+    pub auth_pipeline: Arc<AuthenticationPipeline<User>>,
     pub passive_ports: RangeInclusive<u16>,
     pub passive_host: PassiveHost,
     pub ftps_config: FtpsConfig,
@@ -90,7 +90,7 @@ where
 {
     let Config {
         storage,
-        authenticator,
+        auth_pipeline,
         passive_ports,
         passive_host,
         ftps_config,
@@ -130,7 +130,7 @@ where
     let event_chain = PrimaryEventHandler {
         logger: logger.clone(),
         session: shared_session.clone(),
-        authenticator: authenticator.clone(),
+        auth_pipeline: auth_pipeline.clone(),
         tls_configured,
         passive_ports,
         passive_host,
@@ -328,7 +328,7 @@ where
 {
     logger: slog::Logger,
     session: SharedSession<Storage, User>,
-    authenticator: Arc<dyn Authenticator<User>>,
+    auth_pipeline: Arc<AuthenticationPipeline<User>>,
     tls_configured: bool,
     passive_ports: RangeInclusive<u16>,
     passive_host: PassiveHost,
@@ -418,7 +418,7 @@ where
         let args = CommandContext {
             parsed_command: cmd.clone(),
             session: self.session.clone(),
-            authenticator: self.authenticator.clone(),
+            auth_pipeline: self.auth_pipeline.clone(),
             tls_configured: self.tls_configured,
             passive_ports: self.passive_ports.clone(),
             passive_host: self.passive_host.clone(),

--- a/src/server/controlchan/handler.rs
+++ b/src/server/controlchan/handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    auth::{Authenticator, UserDetail},
+    auth::{AuthenticationPipeline, UserDetail},
     server::{
         ControlChanMsg,
         chancomms::ProxyLoopSender,
@@ -34,7 +34,7 @@ where
 {
     pub parsed_command: Command,
     pub session: SharedSession<Storage, User>,
-    pub authenticator: Arc<dyn Authenticator<User>>,
+    pub auth_pipeline: Arc<AuthenticationPipeline<User>>,
     pub tls_configured: bool,
     pub passive_ports: RangeInclusive<u16>,
     pub passive_host: PassiveHost,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -159,7 +159,9 @@
 //! # struct Vfs{};
 //! # impl Vfs { fn new() -> Filesystem { Filesystem::new("/").unwrap() } }
 //! let vfs_provider = Box::new(|| Vfs::new());
-//! let server = libunftp::Server::new(vfs_provider);
+//! let server = libunftp::ServerBuilder::new(vfs_provider)
+//!     .build()
+//!     .unwrap();
 //! ```
 //!
 //! [`Server`]: ../struct.Server.html

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use lazy_static::*;
-use libunftp::auth::{AuthenticationError, Authenticator, Credentials, DefaultUser};
+use libunftp::auth::{AuthenticationError, Authenticator, Credentials, Principal};
 use libunftp::options::{FailedLoginsBlock, FailedLoginsPolicy};
 use std::io::Error;
 use std::net::SocketAddr;
@@ -119,12 +119,14 @@ pub async fn tcp_pasv_connect(addr: SocketAddr) -> Result<TcpStream, Error> {
 pub struct TestAuthenticator;
 
 #[async_trait]
-impl Authenticator<DefaultUser> for TestAuthenticator {
-    async fn authenticate(&self, username: &str, creds: &Credentials) -> Result<DefaultUser, AuthenticationError> {
+impl Authenticator for TestAuthenticator {
+    async fn authenticate(&self, username: &str, creds: &Credentials) -> Result<Principal, AuthenticationError> {
         return match (username, &creds.password) {
             ("test" | "testpol", Some(pwd)) => {
                 if pwd == "test" {
-                    Ok(DefaultUser {})
+                    Ok(Principal {
+                        username: username.to_string(),
+                    })
                 } else {
                     Err(AuthenticationError::BadPassword)
                 }


### PR DESCRIPTION
# Split Authentication from User Detail Providing

| [Related unFTP commit](https://github.com/bolcom/unFTP/commit/72bb99707adfbb04cf79857925fa3f3f05d7cc84) |

## Overview

This PR refactors the authentication system to decouple authentication (verifying credentials) from user detail retrieval (obtaining full user information). The `Authenticator` trait is now non-generic and returns a `Principal` type instead of a generic `User` type.

## Key Changes

### 1. Non-Generic `Authenticator` Trait

**Before:**
```rust
pub trait Authenticator<User> {
    async fn authenticate(&self, username: &str, creds: &Credentials) -> Result<User, AuthenticationError>;
}
```

**After:**
```rust
pub trait Authenticator {
    async fn authenticate(&self, username: &str, creds: &Credentials) -> Result<Principal, AuthenticationError>;
}
```

The `Authenticator` trait is now non-generic and returns a `Principal` (authenticated identity) instead of a full user object.

### 2. New `Principal` Type

Introduced a new `Principal` struct that represents the minimal authenticated user identity:

```rust
pub struct Principal {
    pub username: String,
}
```

This contains only the authenticated username, separating the authentication step from user detail retrieval.

### 3. New `UserDetailProvider` Trait

Introduced a new trait (copied and adapted from unFTP server) to convert a `Principal` into a full `UserDetail` implementation:

```rust
#[async_trait]
pub trait UserDetailProvider {
    type User: UserDetail;
    
    async fn provide_user_detail(&self, principal: &Principal) -> Result<Self::User, UserDetailError>;
}
```

This allows authentication and user detail lookup to be separated, enabling more flexible architectures.

### 4. New `AuthenticationPipeline` Struct

Introduced `AuthenticationPipeline` that combines an `Authenticator` and a `UserDetailProvider`:

```rust
pub struct AuthenticationPipeline<User> {
    authenticator: Arc<dyn Authenticator + Send + Sync>,
    user_provider: Arc<dyn UserDetailProvider<User = User> + Send + Sync>,
}
```

The pipeline provides a unified interface for the two-step authentication process:
1. Authenticate the user (returns `Principal`)
2. Retrieve user details (converts `Principal` to `User: UserDetail`)

### 5. Updated `ServerBuilder`

- Added `with_user_detail_provider()` constructor method
- The `new()` and `with_authenticator()` methods now automatically initializes `DefaultUserDetailProvider`

### 6. Added `DefaultUserDetailProvider`

A convenience implementation that returns `DefaultUser` for simple use cases:

```rust
pub struct DefaultUserDetailProvider;

impl UserDetailProvider for DefaultUserDetailProvider {
    type User = DefaultUser;
    // ...
}
```

## Migration Guide

### For Authenticator Implementations

**Before:**
```rust
impl Authenticator<DefaultUser> for MyAuthenticator {
    async fn authenticate(&self, username: &str, creds: &Credentials) -> Result<DefaultUser, AuthenticationError> {
        // verify credentials
        Ok(DefaultUser {})
    }
}
```

**After:**
```rust
impl Authenticator for MyAuthenticator {
    async fn authenticate(&self, username: &str, creds: &Credentials) -> Result<Principal, AuthenticationError> {
        // verify credentials
        Ok(Principal { username: username.to_string() })
    }
}
```

### For Server Setup

**Before:**
```rust
let server = ServerBuilder::new(storage)
    .with_authenticator(Arc::new(MyAuthenticator))
    .build()?;
```

**After:**
```rust
let server = ServerBuilder::new(storage)
    .with_authenticator(Arc::new(MyAuthenticator))
    .user_detail_provider(Arc::new(DefaultUserDetailProvider))
    .build()?;
```

Or use the new constructor:
```rust
let server = ServerBuilder::with_user_detail_provider(
    storage_generator,
    Arc::new(MyUserDetailProvider)
)
.authenticator(Arc::new(MyAuthenticator))
.build()?;
```

### For Custom User Types

If you have a custom user type, you'll need to implement `UserDetailProvider`:

```rust
#[derive(Debug)]
struct MyUser {
    username: String,
    home: PathBuf,
}

impl UserDetail for MyUser {
    fn home(&self) -> Option<&Path> {
        Some(&self.home)
    }
}

impl Display for MyUser {
    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
        write!(f, "{}", self.username)
    }
}

#[derive(Debug)]
struct MyUserDetailProvider;

#[async_trait]
impl UserDetailProvider for MyUserDetailProvider {
    type User = MyUser;
    
    async fn provide_user_detail(&self, principal: &Principal) -> Result<MyUser, UserDetailError> {
        // Look up user details from database/configuration
        Ok(MyUser {
            username: principal.username.clone(),
            home: PathBuf::from("/home/") / &principal.username,
        })
    }
}
```

## Updated Crates

All authentication crates have been updated:
- `unftp-auth-jsonfile` - Updated to return `Principal`
- `unftp-auth-pam` - Updated to return `Principal`
- `unftp-auth-rest` - Updated to return `Principal`

## Benefits

1. **Separation of Concerns**: Authentication (verifying credentials) is now separate from user detail retrieval
2. **Flexibility**: Different authenticators can work with different user detail providers
3. **Reusability**: Authenticators are no longer tied to specific user types
4. **Testability**: Easier to test authentication and user detail retrieval independently

## Breaking Changes

- `Authenticator<User>` → `Authenticator` (non-generic)
- `Authenticator.authenticate()` now returns `Principal` instead of `User`
- All `unftp-auth-*` crates need to be updated to use the new trait signature

