### PR TITLE
Don't expose AuthenticationPipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 /.idea
 .DS_Store
 cargo-timing*.html
+/.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,14 @@
     - Updated all examples and tests to use the new authentication pattern.
 - [#551](https://github.com/bolcom/libunftp/pull/551) Let authenticators know the FTP Command channel TLS state
 - [#553](https://github.com/bolcom/libunftp/pull/553) Introduced a new "pooled listener" mode
-      (.pooled_listener_mode()) for high-traffic servers.
+  (.pooled_listener_mode()) for high-traffic servers.
     - This mode improves passive connection performance and security by pre-binding all passive ports.
     - Fixed a memory leak in the passive port Switchboard (used by Pooled and Proxy modes). A new scavenger task now
       cleans up expired and orphaned port reservations.
     - Fixed the PORT command (Active Mode) so that it now works correctly in all listener modes.
     - Fixed that the EPSV command is now correctly disabled in Proxy Protocol mode where it is not (yet) supported.
+- **BREAKING**: Removed the deprecated `Server::new` and `Server::with_authenticator` methods. The `ServerBuilder`
+  struct should be used instead.
 
 ### libunftp 0.22.0
 

--- a/src/auth/anonymous.rs
+++ b/src/auth/anonymous.rs
@@ -3,7 +3,6 @@
 use crate::auth::*;
 use async_trait::async_trait;
 
-///
 /// [`Authenticator`] implementation that simply allows everyone.
 ///
 /// # Example

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -83,4 +83,4 @@ mod user;
 pub use user::{DefaultUser, DefaultUserDetailProvider, UserDetail, UserDetailError, UserDetailProvider};
 
 mod pipeline;
-pub use pipeline::AuthenticationPipeline;
+pub(crate) use pipeline::AuthenticationPipeline;

--- a/src/auth/pipeline.rs
+++ b/src/auth/pipeline.rs
@@ -14,22 +14,6 @@ use std::sync::Arc;
 /// 1. Authenticate the user (returns `Principal`)
 /// 2. Retrieve user details (converts `Principal` to `User: UserDetail`)
 ///
-/// # Example
-///
-/// ```rust
-/// use libunftp::auth::{AuthenticationPipeline, Authenticator, UserDetailProvider, Principal, DefaultUser};
-/// use async_trait::async_trait;
-/// use std::sync::Arc;
-///
-/// // Assuming you have a non-generic Authenticator and a UserDetailProvider
-/// // let authenticator = Arc::new(MyAuthenticator);
-/// // let user_provider = Arc::new(MyUserDetailProvider);
-/// // let pipeline = AuthenticationPipeline::new(authenticator, user_provider);
-/// ```
-///
-/// [`Authenticator`]: trait.Authenticator.html
-/// [`UserDetailProvider`]: trait.UserDetailProvider.html
-/// [`UserDetail`]: trait.UserDetail.html
 #[derive(Debug)]
 pub struct AuthenticationPipeline<User>
 where
@@ -44,20 +28,8 @@ where
     User: UserDetail,
 {
     /// Creates a new `AuthenticationPipeline` combining the given authenticator and user provider.
-    ///
-    /// The authenticator returns a `Principal` and the provider converts it to a full `UserDetail`.
     pub fn new(authenticator: Arc<dyn Authenticator + Send + Sync>, user_provider: Arc<dyn UserDetailProvider<User = User> + Send + Sync>) -> Self {
         Self { authenticator, user_provider }
-    }
-
-    /// Returns a reference to the underlying authenticator.
-    pub fn authenticator(&self) -> &Arc<dyn Authenticator + Send + Sync> {
-        &self.authenticator
-    }
-
-    /// Returns a reference to the underlying user detail provider.
-    pub fn user_provider(&self) -> &Arc<dyn UserDetailProvider<User = User> + Send + Sync> {
-        &self.user_provider
     }
 
     /// Authenticates the user and returns the full user detail.


### PR DESCRIPTION
The new utility type AuthenticationPipeline was exposed as a public API. I'm unsure if this is even I type I really want. For now it is useful but I don't want to expose it to the world.