### PR TITLE
Migrate shared dependencies to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,28 @@ missing_docs = "deny"
 [workspace.lints.clippy]
 all = "deny"
 
+[workspace.dependencies]
+async-trait = "0.1.88"
+base64 = "0.22.1"
+bytes = "1.11.1"
+chrono = { version = "0.4.43", default-features = false }
+futures = { version = "0.3.31", default-features = false, features = ["std"] }
+http-body-util = "0.1.3"
+hyper = { version = "1.8.1", features = ["client", "http1"] }
+hyper-rustls = "0.27.7"
+hyper-util = "0.1.20"
+lazy_static = "1.5.0"
+libunftp = { version = "0.22.0", path = ".", default-features = false }
+percent-encoding = "2.3.2"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+tokio = { version = "1.49.0" }
+tokio-stream = "0.1.18"
+tokio-util = { version = "0.7.18" }
+tracing = { version = "0.1.44", default-features = false }
+tracing-attributes = "0.1.31"
+getrandom = "0.3.4"
+
 [features]
 ring = ["rustls/ring", "rustls/logging", "rustls/std", "rustls/tls12"]
 aws_lc_rs = ["rustls/aws_lc_rs", "rustls/logging", "rustls/std", "rustls/tls12"]
@@ -46,14 +68,14 @@ default = ["aws_lc_rs", "prometheus", "proxy_protocol"]
 all = ["aws_lc_rs", "prometheus", "proxy_protocol"]
 
 [dependencies]
-async-trait = "0.1.88"
+async-trait.workspace = true
 bitflags = "2.10.0"
-bytes = "1.11.1"
-chrono = { version = "0.4.43", default-features = false, features = ["clock", "std"] }
+bytes.workspace = true
+chrono = { workspace = true, features = ["clock", "std"] }
 derive_more = { version = "2.1.1", features = ["display"] }
 futures-util = { version = "0.3.31", default-features = false, features = ["alloc", "sink"] }
-getrandom = "0.3.4"
-lazy_static = "1.5.0"
+getrandom.workspace = true
+lazy_static.workspace = true
 md-5 = "0.10.6"
 moka = { version = "0.12.13", default-features = false, features = ["sync"] }
 nix = { version = "0.30.1", default-features = false, features = ["fs"] }
@@ -63,11 +85,11 @@ rustls = { version = "0.23.36", default-features = false }
 slog = { version = "2.8.2", features = ["max_level_trace", "release_max_level_info"] }
 slog-stdlog = "4.1.1"
 thiserror = "2.0.18"
-tokio = { version = "1.49.0", features = ["macros", "rt", "net", "process", "sync", "io-util", "time"] }
+tokio = { workspace = true, features = ["macros", "rt", "net", "process", "sync", "io-util", "time"] }
 tokio-rustls = { version = "0.26.4", default-features = false }
-tokio-util = { version = "0.7.18", features = ["codec"] }
-tracing = { version = "0.1.44", default-features = false }
-tracing-attributes = "0.1.31"
+tokio-util = { workspace = true, features = ["codec"] }
+tracing.workspace = true
+tracing-attributes.workspace = true
 uuid = { version = "1.20.0", features = ["v4"] }
 x509-parser = "0.18.1"
 dashmap = "6.1.0"
@@ -76,7 +98,7 @@ libc = "0.2"
 [dev-dependencies]
 libunftp = { path = "." }
 pretty_assertions = "1.4.1"
-tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 unftp-sbe-fs = { path = "../libunftp/crates/unftp-sbe-fs" }
 
 [lints]

--- a/crates/unftp-auth-jsonfile/Cargo.toml
+++ b/crates/unftp-auth-jsonfile/Cargo.toml
@@ -18,24 +18,24 @@ repository = "https://github.com/bolcom/libunftp/tree/master/crates/unftp-auth-j
 readme = "README.md"
 
 [dependencies]
-async-trait = "0.1.88"
-base64 = "0.22.1"
-bytes = "1.11.1"
+async-trait.workspace = true
+base64.workspace = true
+bytes.workspace = true
 ipnet = "2.11.0"
 iprange = "0.6.7"
-libunftp = { version = "0.22.0", path = "../../", default-features = false }
+libunftp.workspace = true
 ring = "0.17.14"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-tokio = { version = "1.49.0", features = ["rt", "time"] }
-tracing = { version = "0.1.44", default-features = false }
-tracing-attributes = "0.1.31"
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["rt", "time"] }
+tracing.workspace = true
+tracing-attributes.workspace = true
 valid = "0.3.1"
 flate2 = "1.1.9"
 
 [dev-dependencies]
 pretty_env_logger = "0.5.0"
-tokio = { version = "1.49.0", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }
 unftp-sbe-fs = { version = "0.3.0", path = "../unftp-sbe-fs" }
 
 [lints]

--- a/crates/unftp-auth-pam/Cargo.toml
+++ b/crates/unftp-auth-pam/Cargo.toml
@@ -19,16 +19,16 @@ repository = "https://github.com/bolcom/libunftp/tree/master/crates/unftp-auth-p
 readme = "README.md"
 
 [dependencies]
-async-trait = "0.1.88"
-libunftp = { version = "0.22.0", path = "../../", default-features = false }
-tracing = { version = "0.1.44", default-features = false }
-tracing-attributes = "0.1.31"
+async-trait.workspace = true
+libunftp.workspace = true
+tracing.workspace = true
+tracing-attributes.workspace = true
 
 [target.'cfg(target_family = "unix")'.dependencies]
 pam-auth = { package = "pam", version = "0.7.0" }
 
 [dev-dependencies]
-tokio = { version = "1.49.0", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }
 
 [lints]
 workspace = true

--- a/crates/unftp-auth-rest/Cargo.toml
+++ b/crates/unftp-auth-rest/Cargo.toml
@@ -18,24 +18,23 @@ repository = "https://github.com/bolcom/libunftp/tree/hannes/crates/unftp-auth-r
 readme = "README.md"
 
 [dependencies]
-async-trait = "0.1.88"
-http-body-util = "0.1.3"
-hyper = { version = "1.8.1", features = ["client", "http1"] }
-hyper-rustls = "0.27.7"
-hyper-util = "0.1.20"
-libunftp = { version = "0.22.0", path = "../../", default-features = false }
-percent-encoding = "2.3.2"
+async-trait.workspace = true
+http-body-util.workspace = true
+hyper.workspace = true
+hyper-rustls.workspace = true
+hyper-util.workspace = true
+libunftp.workspace = true
+percent-encoding.workspace = true
 regex = "1.12.3"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-tokio = { version = "1.49.0", features = ["rt", "net", "sync", "io-util", "time"] }
-tracing = { version = "0.1.44", default-features = false }
-tracing-attributes = "0.1.31"
-
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["rt", "net", "sync", "io-util", "time"] }
+tracing.workspace = true
+tracing-attributes.workspace = true
 
 [dev-dependencies]
 pretty_env_logger = "0.5.0"
-tokio = { version = "1.49.0", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }
 unftp-sbe-fs = { version = "0.3.0", path = "../unftp-sbe-fs" }
 
 [lints]

--- a/crates/unftp-sbe-fs/Cargo.toml
+++ b/crates/unftp-sbe-fs/Cargo.toml
@@ -24,21 +24,21 @@ aws_lc_rs = ["libunftp/aws_lc_rs"]
 default = ["aws_lc_rs"]
 
 [dependencies]
-async-trait = "0.1.88"
+async-trait.workspace = true
 cfg-if = "1.0"
 cap-std = "4.0"
-futures = { version = "0.3.31", default-features = false, features = ["std"] }
-lazy_static = "1.5.0"
-libunftp = { version = "0.22.0", path = "../../", default-features = false }
+futures.workspace = true
+lazy_static.workspace = true
+libunftp.workspace = true
 path_abs = "0.5.1"
-tokio = { version = "1.49.0", features = ["rt", "net", "sync", "io-util", "time", "fs"] }
-tokio-stream = "0.1.18"
-tracing = { version = "0.1.44", default-features = false }
-tracing-attributes = "0.1.31"
+tokio = { workspace = true, features = ["rt", "net", "sync", "io-util", "time", "fs"] }
+tokio-stream.workspace = true
+tracing.workspace = true
+tracing-attributes.workspace = true
 
 [dev-dependencies]
 async_ftp = "6.0.0"
-async-trait = "0.1.88"
+async-trait.workspace = true
 chrono = "0.4.43"
 libunftp = { path = "../../", features = ["proxy_protocol"] }
 more-asserts = "0.3.1"
@@ -47,14 +47,14 @@ pretty_assertions = "1.4.1"
 pretty_env_logger = "0.5.0"
 regex = "1.12.3"
 rstest = "0.26.1"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde.workspace = true
+serde_json.workspace = true
 slog-async = "2.8.0"
 slog-term = "2.9.2"
 tempfile = "3.24.0"
-tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.22"
-getrandom = "0.3.4"
+getrandom.workspace = true
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 capsicum = { version = "0.4.4", features = ["casper"] }

--- a/crates/unftp-sbe-gcs/Cargo.toml
+++ b/crates/unftp-sbe-gcs/Cargo.toml
@@ -18,32 +18,32 @@ repository = "https://github.com/bolcom/libunftp/tree/master/crates/unftp-sbe-gc
 readme = "README.md"
 
 [dependencies]
-async-trait = "0.1.88"
-base64 = "0.22.1"
-bytes = "1.11.1"
-chrono = { version = "0.4.43", default-features = false, features = ["std", "serde"] }
-futures = { version = "0.3.31", default-features = false, features = ["std"] }
-http-body-util = "0.1.3"
-hyper = { version = "1.8.1", features = ["client", "http1"] }
-hyper-rustls = "0.27.7"
-hyper-util = "0.1.20"
-libunftp = { version = "0.22.0", path = "../../", default-features = false }
+async-trait.workspace = true
+base64.workspace = true
+bytes.workspace = true
+chrono = { workspace = true, features = ["std", "serde"] }
+futures.workspace = true
+http-body-util.workspace = true
+hyper.workspace = true
+hyper-rustls.workspace = true
+hyper-util.workspace = true
+libunftp.workspace = true
 mime = "0.3.17"
-percent-encoding = "2.3.2"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+percent-encoding.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 time = "0.3.47"
-tokio = { version = "1.49.0", features = ["rt", "net", "sync", "io-util", "time", "fs"] }
-tokio-stream = "0.1.18"
-tokio-util = { version = "0.7.18", features = ["codec", "compat"] }
-tracing = { version = "0.1.44", default-features = false }
-tracing-attributes = "0.1.31"
+tokio = { workspace = true, features = ["rt", "net", "sync", "io-util", "time", "fs"] }
+tokio-stream.workspace = true
+tokio-util = { workspace = true, features = ["codec", "compat"] }
+tracing.workspace = true
+tracing-attributes.workspace = true
 yup-oauth2 = { version = "12.1.2", default-features = false, features = ["hyper-rustls", "service-account", "aws-lc-rs"] }
 
 [dev-dependencies]
 async_ftp = "6.0.0"
 clap = { version = "4.5.57", features = ["env"] }
-lazy_static = "1.5.0"
+lazy_static.workspace = true
 more-asserts = "0.3.1"
 path_abs = "0.5.1"
 pretty_assertions = "1.4.1"
@@ -53,5 +53,5 @@ slog-async = "2.8.0"
 slog-stdlog = "4.1.1"
 slog-term = "2.9.2"
 tempfile = "3.24.0"
-tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.22"

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,10 +6,11 @@
 //!
 //! To create a new storage back-end:
 //!
-//! 1. Declare a dependency on the async-trait crate
+//! 1. Declare dependencies on the async-trait and libunftp crates
 //!
 //! ```toml
-//! async-trait = "0.1.50"
+//! async-trait = { workspace = true }
+//! libunftp = { workspace = true }
 //! ```
 //!
 //! 2. Implement the [`StorageBackend`] trait and optionally the [`Metadata`] trait:


### PR DESCRIPTION
## Summary

- Centralize version management by adding a `[workspace.dependencies]` section to the root `Cargo.toml`
- Migrate 20 shared dependencies (async-trait, tokio, tracing, serde, hyper, etc.) used by 2+ crates to workspace references
- Update doc examples in `src/storage/mod.rs` to reflect the new workspace syntax

## Motivation

Dependency versions were duplicated across all 6 crates. Updating a shared dependency required editing multiple `Cargo.toml` files. With workspace dependencies, versions are defined once at the root and member
crates reference them with `workspace = true`, adding crate-specific features as needed.

Also updated doc examples to use the new syntax, ensuring consistency and reducing maintenance overhead.

## Checking

- [x] `make pr-prep` passes (fmt, build, clippy, tests, docs).